### PR TITLE
chore(release): release-please no longer owns GitHub Releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "skip-github-release": true,
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {


### PR DESCRIPTION
## chore(release): let ReleaseGraph own the GitHub Release

Sets `"skip-github-release": true` at the top level of `release-please-config.json`.

Responsibility split with ReleaseGraph (`redtidev1918/releasegraph@v1`):

- **release-please** — Conventional Commits, version bump, CHANGELOG, manifest, Release PR only.
- **ReleaseGraph** — Git tag, GitHub Release object, assets, checksums/metadata, registries, same-version repair, retention.

Today the reusable workflow already passes `skip-github-release: true` as an action input, so no double Release is being created in production. This makes the contract explicit in repo config (defense in depth, and correct if release-please is ever invoked outside the reusable workflow).

No version, tag, or release is created by this change.
