### PR TITLE
feat(api): idempotent direct publish + reuse envelope, /live /ready probes, fast startup, stable webhook secret

### DIFF
--- a/database/db_manager.py
+++ b/database/db_manager.py
@@ -149,6 +149,25 @@ async def init_db():
                 'ON pending_reviews(status, created_at DESC)'
             )
 
+            # Downstream reconciliation keys (PixivFlow ledger / historical dedupe).
+            # Additive, nullable; older rows simply do not participate.
+            for column, ddl in (
+                ("pixiv_id", "TEXT NOT NULL DEFAULT ''"),
+                ("work_type", "TEXT NOT NULL DEFAULT ''"),
+                ("delivery_target", "TEXT NOT NULL DEFAULT ''"),
+            ):
+                try:
+                    await conn.execute(
+                        f"ALTER TABLE pending_reviews ADD COLUMN {column} {ddl}"
+                    )
+                except Exception:
+                    pass  # column already exists
+            await conn.execute(
+                'CREATE INDEX IF NOT EXISTS idx_pending_reviews_dedupe '
+                "ON pending_reviews(delivery_target, work_type, pixiv_id) "
+                "WHERE pixiv_id <> ''"
+            )
+
             # API 运维通知的持久幂等记录。不同 token 所绑定的用户可以复用同一业务键；
             # 同一用户在 Bot 重启后仍不会重复发送同一条通知。
             await conn.execute('''
@@ -214,6 +233,30 @@ async def init_db():
             await conn.execute('CREATE INDEX IF NOT EXISTS idx_deleted_heat ON published_posts(is_deleted, heat_score DESC)')
             await conn.execute('CREATE INDEX IF NOT EXISTS idx_deleted_publish_time ON published_posts(is_deleted, publish_time DESC)')
             await conn.execute('CREATE INDEX IF NOT EXISTS idx_user_deleted ON published_posts(user_id, is_deleted)')
+
+            # Direct-publish delivery ledger (API_REVIEW_REQUIRED=false). The review
+            # path already dedupes on pending_reviews.idempotency_key; direct publish had
+            # NO idempotency, so an ACK loss / client retry re-posted to the channel.
+            # One row per confirmed channel post, keyed by the caller's idempotency key.
+            await conn.execute('''
+                CREATE TABLE IF NOT EXISTS delivery_ledger (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    idempotency_key TEXT UNIQUE NOT NULL,
+                    target_id TEXT NOT NULL DEFAULT '',
+                    pixiv_id TEXT NOT NULL DEFAULT '',
+                    work_type TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'published',
+                    message_id INTEGER,
+                    related_message_ids TEXT NOT NULL DEFAULT '[]',
+                    user_id INTEGER,
+                    created_at REAL NOT NULL
+                )
+            ''')
+            await conn.execute(
+                'CREATE INDEX IF NOT EXISTS idx_delivery_ledger_dedupe '
+                "ON delivery_ledger(target_id, work_type, pixiv_id) "
+                "WHERE pixiv_id <> ''"
+            )
 
             # published_posts 是频道现状，pending_reviews 是审核审计。频道消息被软删除时
             # 同步把对应审核记录从“曾发布”推进到“已删除”，避免把历史终态误当成

--- a/docs/API.md
+++ b/docs/API.md
@@ -75,7 +75,7 @@ curl -X POST 'https://example.com/api/bot1/v1/submissions' \
 | `link` | 否 | 必须以 `http://` 或 `https://` 开头 |
 | `anonymous` | 否 | `true`、`1`、`yes` 为真 |
 | `spoiler` | 否 | 同上 |
-| `idempotency_key` | 否 | 最长 240；只在审核模式防止重复入队 |
+| `idempotency_key` | 强烈建议 | 最长 240；审核模式防重复入队，直发模式防重复发帖（ACK 丢失重试安全） |
 | `target_id` | 否 | 最长 120；审核模式标识自动化来源，供定向重抓 |
 | `source_label` | 否 | 最长 80；人类可读来源标签（如 `PixivFlow · 每日推荐`）。审核控制卡上展示；TelePost 不解析其含义，缺省不显示 |
 | `source_ref` | 否 | 最长 160；机器可读、稳定的来源引用（如上游 job/execution id）。仅存档/排查，TelePost 不解释其结构 |
@@ -135,13 +135,16 @@ curl -X POST 'https://example.com/api/bot1/v1/notifications' \
 
 ## 响应
 
-立即发布成功：
+### 直发模式（`API_REVIEW_REQUIRED=false`）
+
+首次发布成功（HTTP 200）：
 
 ```json
 {
   "ok": true,
   "data": {
     "status": "published",
+    "reused": false,
     "message_id": 123,
     "link": "https://t.me/channel/123",
     "media_count": 1,
@@ -150,10 +153,36 @@ curl -X POST 'https://example.com/api/bot1/v1/notifications' \
 }
 ```
 
-`API_REVIEW_REQUIRED=true` 时成功响应为 `201`，`status` 是 `pending_review`，并包含
-`review_id` 和 `reused`。`reused=true` 表示命中了现有幂等记录；TelePost 会补齐缺失的
-`target_id` 并在审核群发送复用提示。只有审核群上传和 SQLite 记录都成功后才返回 201；上游收到非 2xx 时应
-保留任务并重试。
+上游在收到响应前超时/断连时，应**用同一个 `idempotency_key` 原样重试**。此时不会产生
+第二条频道消息，响应为 HTTP 200 且：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "status": "published",
+    "reused": true,
+    "reuse_reason": "idempotent_replay",
+    "matched_idempotency_key": "source:123",
+    "message_id": 123
+  }
+}
+```
+
+`reuse_reason` 有两种语义，上游都应按成功处理、**不得再次补发**：
+
+| reuse_reason | 含义 |
+|---|---|
+| `idempotent_replay` | 同一个 `idempotency_key` 的重试（典型：ACK 丢失）。返回的 `message_id` 就是第一次发布的那条，频道里只有一条消息。 |
+| `duplicate_existing` | `idempotency_key` 不同（新的 slot/触发），但同一作品（target+type+pixiv_id）在去重窗口内已由**另一次意图**发布过。不创建新消息，`matched_idempotency_key` 指向先发布的那条。 |
+
+### 审核模式（`API_REVIEW_REQUIRED=true`）
+
+成功响应为 `201`，`status` 是 `pending_review`，并包含 `review_id` 和 `reused`。
+`reused=true` 时同样带 `reuse_reason`（`idempotent_replay` / `duplicate_existing`）
+与 `matched_idempotency_key`；TelePost 会补齐缺失的 `target_id` 并在审核群发送复用提示。
+只有审核群上传和 SQLite 记录都成功后才返回 201；上游收到非 2xx 时应保留任务并用同一
+`idempotency_key` 重试。
 
 同一 `idempotency_key` 命中待审核、失败或 7 天内已发布记录时，不重复上传媒体或
 创建审核记录，但会在当前审核群发送一条提示，引用原审核编号并显示状态。因此每次

--- a/docs/FLYIO_DEPLOYMENT.md
+++ b/docs/FLYIO_DEPLOYMENT.md
@@ -84,12 +84,21 @@ TelePost 启动时会自行调用 Telegram `setWebhook`；不需要手工注册�
 ```bash
 flyctl status --app <app>
 flyctl logs --app <app>
-curl -fsS https://<app>.fly.dev/health
+curl -fsS https://<app>.fly.dev/live
+curl -fsS https://<app>.fly.dev/ready
 curl -fsS https://<app>.fly.dev/api/v1/health
 curl -fsS 'https://api.telegram.org/bot<TOKEN>/getWebhookInfo'
 ```
 
-`/health` 返回 JSON；API 健康响应中的 `bot_version` 应等于部署版本。
+三个探针语义不同：
+
+| 端点 | 语义 | 用途 |
+|---|---|---|
+| `/live` | 路由进程存活即 200，恒不阻塞 | 存活探针、外部保活 ping |
+| `/ready` | 所有 Bot 子进程 `initialize()+start()` 完成才 200，冷启动中 503 | **Fly 健康检查打这个**；proxy 会等它就绪再转发唤醒请求 |
+| `/health` | 路由存活 + 容量/存储指标，恒 200 | 观测与 auto-stop 唤醒入口，**不**代表业务就绪 |
+
+API 健康响应中的 `bot_version` 应等于部署版本。
 `getWebhookInfo` 应核对 URL、`pending_update_count`、`last_error_date` 和
 `last_error_message`，不要把完整响应连同 Token 贴到公开 Issue。
 
@@ -120,9 +129,15 @@ flyctl secrets set --app <telepost-app> \
 
 [http_service]
   internal_port = 8080
-  auto_stop_machines = "stop"
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 0
+
+[[http_service.checks]]
+  grace_period = "60s"
+  interval = "30s"
+  timeout = "10s"
+  path = "/ready"
 
 [[vm]]
   cpu_kind = "shared"
@@ -139,7 +154,12 @@ Fly Proxy 的 autostop/autostart 只停止或启动现有 Machine，不会删除
 
 - 正常关机只停止本地 HTTP 服务，不注销 Telegram Webhook。
 - 冷启动重新注册 Webhook 时不丢弃待处理更新。
-- 多 Bot 父路由会等待子进程端口最多 5 秒，避免刚唤醒时首个请求过早收到 502。
+- 多 Bot 父路由先等子进程端口、再轮询子进程 `/ready`（有界，默认最多 30 秒），
+  Bot 未完成 `initialize()+start()` 前不会把 webhook 转发给半热的子进程。
+- 自动休眠使用 `suspend`：挂起期间与 `stop` 一样不计 CPU/RAM，但唤醒是 Firecracker
+  快照恢复（几百毫秒），不是完整冷启动。
+- Webhook secret 持久化在数据卷，跨重启/唤醒稳定，不会出现"重启到重新 setWebhook
+  之间所有更新 403"的窗口。
 - Telegram Webhook、HTTP API 和 PixivFlow 的 Flycast 请求都会经过 Fly Proxy，触发
   `auto_start_machines=true`。
 
@@ -149,9 +169,10 @@ Fly Proxy 的 autostop/autostart 只停止或启动现有 Machine，不会删除
 验证冷启动：
 
 ```bash
-flyctl machine stop <machine-id> --app <app>
+flyctl machine suspend <machine-id> --app <app>
 flyctl machine status <machine-id> --app <app>
-curl -fsS -w 'time=%{time_total}s\n' https://<app>.fly.dev/health
+# 唤醒期间 /ready 先返回 503、就绪后 200；/live 立即 200
+curl -fsS -w 'time=%{time_total}s\n' https://<app>.fly.dev/ready
 ```
 
 最后再次检查两个 Webhook URL 和待处理数。

--- a/handlers/publish.py
+++ b/handlers/publish.py
@@ -994,8 +994,69 @@ async def handle_document_publish(context, doc_list, caption=None, reply_to_mess
     return main
 
 
+async def _ledger_find_by_key(idempotency_key: str):
+    if not idempotency_key:
+        return None
+    async with get_db() as conn:
+        cursor = await conn.execute(
+            "SELECT * FROM delivery_ledger WHERE idempotency_key=?",
+            (idempotency_key,),
+        )
+        return await cursor.fetchone()
+
+
+async def _ledger_find_work(target_id: str, work_type: str, pixiv_id: str, window_seconds: int):
+    if not pixiv_id:
+        return None
+    async with get_db() as conn:
+        sql = (
+            "SELECT * FROM delivery_ledger WHERE pixiv_id=? AND work_type=? "
+            "AND status='published' AND created_at >= ?"
+        )
+        params = [pixiv_id, work_type, time.time() - window_seconds]
+        if target_id:
+            sql += " AND target_id=?"
+            params.append(target_id)
+        sql += " ORDER BY created_at DESC LIMIT 1"
+        cursor = await conn.execute(sql, params)
+        return await cursor.fetchone()
+
+
+async def _ledger_record(idempotency_key: str, *, target_id, pixiv_id, work_type,
+                         message_id, related_message_ids, user_id):
+    if not idempotency_key:
+        return False
+    async with get_db() as conn:
+        try:
+            await conn.execute(
+                "INSERT INTO delivery_ledger "
+                "(idempotency_key, target_id, pixiv_id, work_type, status, message_id, "
+                "related_message_ids, user_id, created_at) "
+                "VALUES (?, ?, ?, ?, 'published', ?, ?, ?, ?)",
+                (idempotency_key, target_id or "", pixiv_id or "", work_type or "",
+                 message_id, json.dumps(related_message_ids or []), user_id, time.time()),
+            )
+            return True
+        except Exception:
+            # UNIQUE race / replay: the other attempt owns the channel post.
+            return False
+
+
+def _ledger_replay(row) -> dict:
+    return {
+        "status": "published",
+        "message_id": row["message_id"],
+        "link": _link_of(row["message_id"]) if row["message_id"] else "",
+        "reused": True,
+        "reuse_reason": "idempotent_replay",
+        "matched_idempotency_key": row["idempotency_key"],
+        "delivery_status": "published",
+    }
+
+
 async def publish_from_files(bot, files, *, tags="", title="", note="", link="",
-                             anonymous=False, spoiler=False, user_id, username="") -> dict:
+                             anonymous=False, spoiler=False, user_id, username="",
+                             idempotency_key="", target_id="", work_type="", pixiv_id="") -> dict:
     """
     API 投稿核心：把本地文件直接发布到频道（不经 Telegram 会话流程）。
 
@@ -1007,6 +1068,28 @@ async def publish_from_files(bot, files, *, tags="", title="", note="", link="",
     import os as _os
     from contextlib import ExitStack
     from telegram import InputFile
+
+    from handlers.review import PUBLISHED_DEDUP_WINDOW_SECONDS, _pixiv_id_from_link
+    key = idempotency_key.strip()[:240]
+    pid = (pixiv_id or _pixiv_id_from_link(link or "")).strip()
+    replay = await _ledger_find_by_key(key)
+    if replay is not None:
+        for fobj in files:
+            try:
+                os.remove(fobj["path"])
+            except OSError:
+                pass
+        return _ledger_replay(replay)
+    historical = await _ledger_find_work(target_id, work_type, pid, PUBLISHED_DEDUP_WINDOW_SECONDS)
+    if historical is not None and historical["idempotency_key"] != key:
+        for fobj in files:
+            try:
+                os.remove(fobj["path"])
+            except OSError:
+                pass
+        result = _ledger_replay(historical)
+        result["reuse_reason"] = "duplicate_existing"
+        return result
 
     data = {
         "tags": tags, "title": title, "note": note, "link": link,
@@ -1040,6 +1123,9 @@ async def publish_from_files(bot, files, *, tags="", title="", note="", link="",
             media_list.append(f"{item['kind']}:{file_id}")
 
     await save_published_post(user_id, main_message.message_id, data, media_list, doc_list, all_message_ids)
+    await _ledger_record(key, target_id=target_id, pixiv_id=pid, work_type=work_type,
+                         message_id=main_message.message_id,
+                         related_message_ids=all_message_ids, user_id=user_id)
 
     if str(CHANNEL_ID).startswith("@"):
         link = f"https://t.me/{str(CHANNEL_ID).lstrip('@')}/{main_message.message_id}"
@@ -1071,7 +1157,8 @@ def _link_of(message_id: int) -> str:
 
 
 async def publish_from_file_ids(bot, media, documents, *, tags="", title="", note="", link="",
-                                anonymous=False, spoiler=False, user_id, username="") -> dict:
+                                anonymous=False, spoiler=False, user_id, username="",
+                                idempotency_key="", target_id="", work_type="", pixiv_id="") -> dict:
     """
     API file_id 直投核心：素材已在 Telegram 服务器上（file_id 归属本 bot），
     直接用 file_id 发布到频道——零媒体文件传输。
@@ -1079,6 +1166,18 @@ async def publish_from_file_ids(bot, media, documents, *, tags="", title="", not
     media:     [{"type": "photo|video|animation|audio", "file_id": str}]
     documents: [{"file_id": str, "filename": str}]
     """
+    from handlers.review import PUBLISHED_DEDUP_WINDOW_SECONDS, _pixiv_id_from_link
+    key = idempotency_key.strip()[:240]
+    pid = (pixiv_id or _pixiv_id_from_link(link or "")).strip()
+    replay_row = await _ledger_find_by_key(key)
+    if replay_row is not None:
+        return _ledger_replay(replay_row)
+    historical_row = await _ledger_find_work(target_id, work_type, pid, PUBLISHED_DEDUP_WINDOW_SECONDS)
+    if historical_row is not None and historical_row["idempotency_key"] != key:
+        out = _ledger_replay(historical_row)
+        out["reuse_reason"] = "duplicate_existing"
+        return out
+
     data = {
         "tags": tags, "title": title, "note": note, "link": link,
         "spoiler": "true" if spoiler else "false",
@@ -1107,6 +1206,9 @@ async def publish_from_file_ids(bot, media, documents, *, tags="", title="", not
     doc_list = [f"document:{d['file_id']}:{d.get('filename', 'file')}" for d in documents]
 
     await save_published_post(user_id, main_message.message_id, data, media_list, doc_list, all_message_ids)
+    await _ledger_record(key, target_id=target_id, pixiv_id=pid, work_type=work_type,
+                         message_id=main_message.message_id,
+                         related_message_ids=all_message_ids, user_id=user_id)
 
     return {
         "status": "published",
@@ -1114,6 +1216,7 @@ async def publish_from_file_ids(bot, media, documents, *, tags="", title="", not
         "link": _link_of(main_message.message_id),
         "media_count": len(media_list),
         "document_count": len(doc_list),
+        "delivery_status": "published",
     }
 
 def _file_id_of(message):

--- a/handlers/review.py
+++ b/handlers/review.py
@@ -145,7 +145,7 @@ def _caption_data(*, tags, title, note, link, anonymous, spoiler, user_id, usern
     }
 
 
-def _result_from_row(row, *, reused: bool = False) -> dict:
+def _result_from_row(row, *, reused: bool = False, reuse_reason: str = "") -> dict:
     status = "pending_review" if row["status"] == "pending" else row["status"]
     result = {
         "status": status,
@@ -154,6 +154,12 @@ def _result_from_row(row, *, reused: bool = False) -> dict:
         "document_count": len(json.loads(row["documents_json"] or "[]")),
         "reused": reused,
     }
+    if reused:
+        # Distinguish an ACK-loss replay of the SAME intent from a DIFFERENT
+        # intent for a work already published by another slot/key.
+        result["reuse_reason"] = reuse_reason or "idempotent_replay"
+        result["matched_idempotency_key"] = row["idempotency_key"]
+        result["delivery_status"] = status
     if row["published_message_id"]:
         result["message_id"] = row["published_message_id"]
     return result
@@ -255,7 +261,7 @@ async def _notify_reused_review(bot, row) -> None:
     )
 
 
-async def _reuse_review(bot, row, target_id: str = "") -> dict:
+async def _reuse_review(bot, row, target_id: str = "", reuse_reason: str = "idempotent_replay") -> dict:
     """Backfill source identity, notify reviewers, and return a reusable result."""
     if target_id and not row["target_id"]:
         async with get_db() as conn:
@@ -265,7 +271,28 @@ async def _reuse_review(bot, row, target_id: str = "") -> dict:
                 (target_id, time.time(), row["id"]),
             )
     await _notify_reused_review(bot, row)
-    return _result_from_row(row, reused=True)
+    return _result_from_row(row, reused=True, reuse_reason=reuse_reason)
+
+
+async def _find_published_work(target_id: str, work_type: str, pixiv_id: str):
+    """Find a recently PUBLISHED review for the same downstream work+target under a
+    DIFFERENT idempotency key. This is the cross-intent historical duplicate case
+    (e.g. a new occurrence selecting a work already posted by an older slot)."""
+    if not pixiv_id:
+        return None
+    async with get_db() as conn:
+        sql = (
+            "SELECT * FROM pending_reviews "
+            "WHERE status='published' AND work_type=? AND pixiv_id=? "
+            "AND decided_at >= ?"
+        )
+        params: list = [work_type, pixiv_id, time.time() - PUBLISHED_DEDUP_WINDOW_SECONDS]
+        if target_id:
+            sql += " AND target_id=?"
+            params.append(target_id)
+        sql += " ORDER BY decided_at DESC LIMIT 1"
+        cursor = await conn.execute(sql, params)
+        return await cursor.fetchone()
 
 
 async def expire_stale_reviews(bot, *, now: Optional[float] = None) -> int:
@@ -903,15 +930,25 @@ async def queue_review_from_files(
     source_label="",
     source_ref="",
     scheduled_at="",
+    work_type="",
 ) -> dict:
     """Stage multipart API files and create a durable pending review."""
     key = _normalized_idempotency_key(user_id, idempotency_key, source)
     existing = await _find_review(key)
     if existing is not None:
         try:
-            return await _reuse_review(bot, existing, target_id)
+            return await _reuse_review(bot, existing, target_id, "idempotent_replay")
         finally:
             _cleanup_local_files(files)
+
+    pixiv_id = _pixiv_id_from_link(link or "")
+    if pixiv_id:
+        historical = await _find_published_work(target_id, work_type, pixiv_id)
+        if historical is not None and historical["idempotency_key"] != key:
+            try:
+                return _result_from_row(historical, reused=True, reuse_reason="duplicate_existing")
+            finally:
+                _cleanup_local_files(files)
 
     data = _caption_data(
         tags=tags, title=title, note=note, link=link,
@@ -941,6 +978,8 @@ async def queue_review_from_files(
             source_label=source_label,
             source_ref=source_ref,
             scheduled_at=scheduled_at,
+            pixiv_id=pixiv_id,
+            work_type=work_type,
         )
     except Exception:
         await _delete_messages(bot, preview_ids)

--- a/main.py
+++ b/main.py
@@ -248,6 +248,31 @@ async def setup_bot_commands(application):
         logger.error(f"设置命令菜单失败: {e}", exc_info=True)
 
 
+def _load_or_create_persisted_webhook_secret() -> str:
+    """Return a stable webhook secret persisted next to the database.
+
+    Survives machine stop/restart so the secret Telegram already has stays
+    valid even before the first setWebhook of a fresh process. File is 0600.
+    """
+    try:
+        secret_path = os.path.join(os.path.dirname(DB_PATH) or "data", "webhook.secret")
+        os.makedirs(os.path.dirname(secret_path), exist_ok=True)
+        if os.path.exists(secret_path):
+            with open(secret_path, "r", encoding="utf-8") as fh:
+                value = fh.read().strip()
+                if value:
+                    return value
+        value = __import__("secrets").token_urlsafe(32)
+        fd = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(value)
+        logger.info("已生成并持久化 Webhook Secret Token（值不写入日志）")
+        return value
+    except Exception as exc:  # read-only FS fallback: ephemeral but still functional
+        logger.warning("无法持久化 Webhook Secret，回退为本次启动随机值: %s", exc)
+        return __import__("secrets").token_urlsafe(32)
+
+
 async def main():
     """
     主函数 - 设置并启动机器人
@@ -262,68 +287,48 @@ async def main():
     # 初始化黑名单
     await init_blacklist()
     
-    # 初始化搜索引擎
-    logger.info("正在初始化搜索引擎...")
-    try:
-        from config.settings import SEARCH_INDEX_DIR, SEARCH_ENABLED
-        if SEARCH_ENABLED:
-            # 初始化搜索引擎（内置兼容性检查和自动重建）
-            search_engine = init_search_engine(index_dir=SEARCH_INDEX_DIR, from_scratch=False)
+    # 搜索引擎（Whoosh）初始化/同步/重建被推迟到机器人 READY 之后后台执行。
+    # 它是可降级的非关键能力：大索引重建曾同步阻塞事件循环，把冷启动从
+    # 秒级拉长到分钟级，并卡住健康检查/Webhook 绑定。搜索未就绪时命令侧
+    # 自行降级提示，绝不拖慢 bot 上线。
+    async def _post_ready_search_init():
+        logger.info("正在初始化搜索引擎（后台，不阻塞上线）...")
+        try:
+            from config.settings import SEARCH_INDEX_DIR, SEARCH_ENABLED
+            if not SEARCH_ENABLED:
+                logger.info("搜索功能已禁用")
+                return
+            def _init_blocking():
+                return init_search_engine(index_dir=SEARCH_INDEX_DIR, from_scratch=False)
+            search_engine = await asyncio.to_thread(_init_blocking)
             logger.info(f"搜索引擎初始化完成，索引目录: {SEARCH_INDEX_DIR}")
-            
-            # 检查是否需要重新索引
-            if hasattr(search_engine, '_needs_reindex') and search_engine._needs_reindex:
+            if hasattr(search_engine, "_needs_reindex") and search_engine._needs_reindex:
                 logger.warning("检测到索引已重建，需要重新索引所有帖子")
-                logger.info("正在从数据库重新索引...")
                 try:
                     result = await auto_rebuild_index_if_needed()
-                    # 返回结构: {"action": "sync"|"rebuild"|"none"|"failed", "result": {...}, ...}
                     action = result.get("action")
-                    inner = result.get("result") or {}
-                    if action == "none":
-                        logger.info("✅ 索引无需重建，已同步")
-                        search_engine._needs_reindex = False
-                    elif action == "sync" and inner.get("success"):
-                        logger.info("✅ 索引已自动同步")
-                        search_engine._needs_reindex = False
-                    elif action == "rebuild" and inner.get("success"):
-                        logger.info("✅ 索引重建成功！")
-                        search_engine._needs_reindex = False
-                    else:
-                        logger.warning(f"⚠️ 索引检查/重建未完全成功 (action={action})，搜索功能可能受限")
+                    if action in ("none", "sync", "rebuild"):
+                        ok = (result.get("result") or {}).get("success", action == "none")
+                        if ok:
+                            search_engine._needs_reindex = False
+                            logger.info("后台索引重建/同步完成 action=%s", action)
+                        else:
+                            logger.warning("后台索引处理未完全成功 action=%s", action)
                 except Exception as rebuild_err:
                     logger.error(f"自动重建索引失败: {rebuild_err}", exc_info=True)
-                    logger.warning("搜索功能可能不可用，请手动执行 /rebuild_index")
             else:
-                # 正常的索引检查和同步
-                logger.info("正在检查搜索索引...")
                 try:
                     result = await auto_rebuild_index_if_needed()
-                    if result["action"] == "sync":
-                        sync_result = result["result"]
-                        if sync_result["success"]:
-                            logger.info(f"✅ 索引已自动同步: 添加 {sync_result['added']} 个, 删除 {sync_result['removed']} 个")
-                        else:
-                            logger.warning(f"⚠️ 索引同步部分失败: {sync_result.get('errors', [])}")
-                    elif result["action"] == "rebuild":
-                        rebuild_result = result["result"]
-                        if rebuild_result["success"]:
-                            logger.info(f"✅ 索引已自动重建: 成功 {rebuild_result['added']} 个, 失败 {rebuild_result['failed']} 个 (原因: {result.get('reason', '未知')})")
-                        else:
-                            logger.warning(f"⚠️ 索引重建失败: {rebuild_result.get('errors', [])}")
-                    elif result["action"] == "none":
-                        logger.info(f"✅ {result['reason']}")
-                    else:
-                        logger.warning(f"⚠️ 索引检查失败: {result.get('reason', '未知原因')}")
+                    if result.get("action") == "sync" and (result.get("result") or {}).get("success"):
+                        logger.info("后台索引增量同步完成")
                 except Exception as idx_err:
-                    logger.error(f"索引检查失败: {idx_err}", exc_info=True)
-                    logger.warning("将继续运行，但索引可能不准确")
-        else:
-            logger.info("搜索功能已禁用")
-    except Exception as e:
-        logger.error(f"搜索引擎初始化失败: {e}", exc_info=True)
-        logger.warning("将继续运行，但搜索功能可能不可用")
-    
+                    logger.error(f"后台索引检查失败: {idx_err}", exc_info=True)
+        except Exception as e:
+            logger.error(f"搜索引擎初始化失败: {e}", exc_info=True)
+            logger.warning("将继续运行，但搜索功能可能不可用")
+
+    post_ready_tasks = []
+
     # 创建和启动应用程序
     token = TOKEN
     if not token:
@@ -347,8 +352,8 @@ async def main():
     await application.initialize()
     await application.start()
     
-    # 设置命令菜单
-    await setup_bot_commands(application)
+    # 命令菜单是非关键 Telegram API 调用，放到上线后后台设置，避免其
+    # 网络延迟/限流拖慢就绪。
     
     # 根据运行模式选择启动方式
     webhook_server = None
@@ -377,11 +382,12 @@ async def main():
         # 导入 Webhook 服务器模块
         from utils.webhook_server import WebhookServer, setup_webhook
         
-        # 生成或使用 Secret Token
-        import secrets
-        secret_token = WEBHOOK_SECRET_TOKEN or secrets.token_urlsafe(32)
-        if not WEBHOOK_SECRET_TOKEN:
-            logger.info("已自动生成 Webhook Secret Token（值不写入日志）")
+        # 使用稳定的 Secret Token。显式配置优先；否则在持久化目录里生成并
+        # 复用同一枚 token——auto_stop 唤醒/进程重启后 Telegram 仍按已注册的
+        # secret 投递，随机 token 会在“重启到重新 setWebhook”的窗口里把更新
+        # 全部判为非法（403）。
+        import secrets as _secrets
+        secret_token = WEBHOOK_SECRET_TOKEN or _load_or_create_persisted_webhook_secret()
         
         # 创建服务器并向 Telegram 注册。AUTO 模式会把监听端口、DNS、
         # TLS 或 Telegram API 侧的任何启动失败统一回退到 Polling。
@@ -476,6 +482,10 @@ async def main():
                 ),
             )
         
+    # READY: bot 已开始接收更新。现在才跑非关键后台初始化（搜索索引、命令菜单）。
+    post_ready_tasks.append(asyncio.create_task(_post_ready_search_init(), name="post-ready-search"))
+    post_ready_tasks.append(asyncio.create_task(setup_bot_commands(application), name="post-ready-commands"))
+
     logger.info("机器人运行中，使用 Ctrl+C 停止")
     
     # 保持应用程序运行

--- a/run.py
+++ b/run.py
@@ -45,7 +45,7 @@ _STORAGE_METRICS_CACHE = {"expires_at": 0.0, "value": None}
 
 
 async def _wait_for_bot_port(port: int, timeout: float = 5.0) -> None:
-    """Give auto-started bot children a short window to bind their port."""
+    """Give auto-started bot children a bounded window to bind their port."""
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while True:
@@ -58,6 +58,23 @@ async def _wait_for_bot_port(port: int, timeout: float = 5.0) -> None:
             if loop.time() >= deadline:
                 raise
             await asyncio.sleep(0.1)
+
+
+async def _probe_child_ready(port: int, *, timeout: float = 0.8) -> bool:
+    """Return True once a bot child answers GET /ready with 200.
+
+    Readiness (PTB app running) is distinct from a bound socket: after a cold
+    start the relay no longer 502s a webhook that arrives in the window between
+    'port open' and 'bot initialized'. Bounded and tolerant: any failure reads
+    as 'not ready yet' rather than raising into the relay.
+    """
+    from aiohttp import ClientSession, ClientTimeout
+    try:
+        async with ClientSession(timeout=ClientTimeout(total=timeout)) as session:
+            async with session.get(f"http://127.0.0.1:{port}/ready") as resp:
+                return resp.status == 200
+    except Exception:
+        return False
 
 
 def _process_rss_snapshot(proc_root: str = "/proc") -> list[dict]:
@@ -458,9 +475,32 @@ def build_router_app(indices: list):
     # The router never buffers submission bodies. The explicit size ceiling is
     # still useful for malformed clients and matches TelePost's 500 MiB API cap
     # (up to 50 files, 50 MiB each).
+    async def live(_request):
+        # Liveness: this routing process is up. Independent of child startup so
+        # the orchestrator never kills a healthy parent that is still warming
+        # cold bot children (killing it would just restart the warm-up).
+        return web.json_response({"status": "ok", "service": "telepost", "kind": "live"})
+
+    async def ready(_request):
+        # Readiness: every bot child has finished initialize()+start(). Bounded
+        # probes in parallel; a not-yet-ready child returns 503 without faking
+        # success (HTTP 200 never implied business readiness).
+        results = await asyncio.gather(*(
+            _probe_child_ready(bot_webhook_port(index)) for index in indices
+        )) if indices else [True]
+        all_ready = all(results)
+        return web.json_response(
+            {"status": "ok" if all_ready else "starting",
+             "kind": "ready",
+             "bots": {f"bot{index}": bool(ok) for index, ok in zip(indices, results)}},
+            status=200 if all_ready else 503,
+        )
+
     app = web.Application(client_max_size=ROUTER_CLIENT_MAX_BYTES)
     app.cleanup_ctx.append(client_session_context)
     app.router.add_get("/health", health)
+    app.router.add_get("/live", live)
+    app.router.add_get("/ready", ready)
 
     def make_relay(index: int, strip: str | None, prepend: str = "", port_override: int | None = None):
         async def relay(request):
@@ -481,7 +521,17 @@ def build_router_app(indices: list):
             }
             downstream = None
             try:
-                await _wait_for_bot_port(port)
+                # Bound socket first, then actual bot readiness. Cap the wait so
+                # a wedged child fails fast as 502 instead of hanging the webhook.
+                ready_deadline = float(os.environ.get("ROUTER_CHILD_READY_TIMEOUT", "30"))
+                waited = 0.0
+                ready = await _probe_child_ready(port)
+                while not ready and waited < ready_deadline:
+                    await asyncio.sleep(0.2)
+                    waited += 0.2
+                    ready = await _probe_child_ready(port)
+                if not ready:
+                    raise TimeoutError(f"bot child on port {port} not ready after {ready_deadline}s")
                 session = request.app[session_key]
                 async with session.request(
                     request.method,

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -550,8 +550,12 @@ class TestRouterApiRelay:
 
         monkeypatch.setattr(run_mod, "bot_webhook_port", lambda i: 18091 if i == 1 else 18092)
 
+        async def fake_ready(_request):
+            return web.json_response({"ready": True})
+
         bot_app = web.Application()
         bot_app.router.add_get("/api/v1/me", fake_v1_me)
+        bot_app.router.add_get("/ready", fake_ready)
         bot_runner = web.AppRunner(bot_app)
         await bot_runner.setup()
         bot_site = web.TCPSite(bot_runner, "127.0.0.1", 18091)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -399,8 +399,40 @@ class TestFileIdDirect:
             file_id_mock.assert_called_once()
             kwargs = file_id_mock.call_args.kwargs
             assert kwargs["anonymous"] is True
-            assert "target_id" not in kwargs
+            # Direct publish now carries idempotency/dedupe identity through so
+            # an ACK loss / retry cannot re-post to the channel.
+            assert kwargs["target_id"] == ""
+            assert kwargs["work_type"] == ""
+            assert kwargs["pixiv_id"] == ""
             assert file_id_mock.call_args.args[1][0]["file_id"] == "AAA"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_idempotency_fields_passed_through(self, monkeypatch):
+        file_id_mock = AsyncMock(return_value={"status": "published", "message_id": 1})
+        monkeypatch.setattr("handlers.publish.publish_from_file_ids", file_id_mock)
+        app, _ = _make_app(monkeypatch, _TOKEN_ROW)
+        client = await _client(app)
+        try:
+            resp = await client.post(
+                "/api/v1/submissions",
+                headers={"Authorization": "Bearer tp_ok"},
+                json={
+                    "media": [{"type": "photo", "file_id": "A"}],
+                    "tags": "t",
+                    "idempotency_key": "pixivflow:bot1:illustration:55:slot:t1",
+                    "target_id": "bot1",
+                    "work_type": "illustration",
+                    "pixiv_id": "55",
+                },
+            )
+            assert resp.status == 201
+            kwargs = file_id_mock.call_args.kwargs
+            assert kwargs["idempotency_key"] == "pixivflow:bot1:illustration:55:slot:t1"
+            assert kwargs["target_id"] == "bot1"
+            assert kwargs["work_type"] == "illustration"
+            assert kwargs["pixiv_id"] == "55"
         finally:
             await client.close()
 

--- a/tests/test_polling_server.py
+++ b/tests/test_polling_server.py
@@ -34,3 +34,18 @@ async def test_polling_mode_can_disable_api(monkeypatch):
     async with TestClient(TestServer(app)) as client:
         assert (await client.get("/health")).status == 200
         assert (await client.get("/api/v1/health")).status == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running,expected", [(False, 503), (True, 200)])
+async def test_polling_ready_reflects_ptb_running_state(running, expected):
+    from aiohttp.test_utils import TestClient, TestServer
+
+    app = build_polling_app(SimpleNamespace(bot=object(), running=running))
+    async with TestClient(TestServer(app)) as client:
+        live = await client.get("/live")
+        assert live.status == 200  # liveness never depends on PTB state
+        ready = await client.get("/ready")
+        assert ready.status == expected
+        body = await ready.json()
+        assert body["ready"] is running

--- a/tests/test_publish_idempotency.py
+++ b/tests/test_publish_idempotency.py
@@ -1,0 +1,70 @@
+"""Direct-publish idempotency (API_REVIEW_REQUIRED=false path).
+
+An ACK loss / client retry must not produce a second channel post:
+- same idempotency key  -> idempotent_replay, no second Telegram send
+- different key, same work already published -> duplicate_existing, no second send
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import database.db_manager as dbm
+from database.db_manager import init_db
+from handlers import publish
+
+
+def _photo_message(message_id: int):
+    return SimpleNamespace(
+        message_id=message_id,
+        chat=None,
+        photo=(SimpleNamespace(file_id=f"fid-{message_id}"),),
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_publish_idempotent_replay_then_historical_duplicate(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(dbm, "DB_PATH", str(db_path))
+    await init_db()
+
+    deliver = AsyncMock(side_effect=[
+        ([_photo_message(100)], _photo_message(100)),
+    ])
+    monkeypatch.setattr(publish, "deliver_items_to_chat", deliver)
+
+    media = [{"type": "photo", "file_id": "AAA"}]
+    common = dict(tags="#t", user_id=1, link="https://www.pixiv.net/artworks/55")
+
+    first = await publish.publish_from_file_ids(
+        None, media, [],
+        idempotency_key="pixivflow:bot1:illustration:55:slot-a:t1",
+        target_id="bot1", work_type="illustration", pixiv_id="55",
+        **common,
+    )
+    assert first["status"] == "published"
+    assert deliver.await_count == 1
+
+    # ACK lost: identical intent retried -> replay, no second Telegram send.
+    replay = await publish.publish_from_file_ids(
+        None, media, [],
+        idempotency_key="pixivflow:bot1:illustration:55:slot-a:t1",
+        target_id="bot1", work_type="illustration", pixiv_id="55",
+        **common,
+    )
+    assert replay["reused"] is True
+    assert replay["reuse_reason"] == "idempotent_replay"
+    assert replay["matched_idempotency_key"].endswith(":slot-a:t1")
+    assert replay["message_id"] == 100
+    assert deliver.await_count == 1
+
+    # New occurrence, different key, same work -> historical duplicate.
+    historical = await publish.publish_from_file_ids(
+        None, media, [],
+        idempotency_key="pixivflow:bot1:illustration:55:slot-b:t1",
+        target_id="bot1", work_type="illustration", pixiv_id="55",
+        **common,
+    )
+    assert historical["reused"] is True
+    assert historical["reuse_reason"] == "duplicate_existing"
+    assert deliver.await_count == 1

--- a/tests/test_webhook_ready.py
+++ b/tests/test_webhook_ready.py
@@ -1,0 +1,30 @@
+"""WebhookServer exposes liveness independent of PTB and readiness gated on
+Application.running, so Fly's /ready check never routes to a half-warmed bot."""
+from types import SimpleNamespace
+
+import pytest
+
+from utils.webhook_server import WebhookServer
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running,expected", [(False, 503), (True, 200)])
+async def test_webhook_live_and_ready(running, expected, unused_tcp_port):
+    from aiohttp.test_utils import TestClient, TestServer
+
+    server = WebhookServer(
+        application=SimpleNamespace(running=running, bot=object()),
+        port=unused_tcp_port,
+        path="/webhook/bot1",
+        secret_token="sec",
+    )
+    try:
+        await server.start()
+        app = server.web_app
+        async with TestClient(TestServer(app)) as client:
+            assert (await client.get("/live")).status == 200
+            ready = await client.get("/ready")
+            assert ready.status == expected
+            assert (await ready.json())["ready"] is running
+    finally:
+        await server.stop()

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -91,8 +91,12 @@ class TestRouterRelay:
             return web.json_response({"status": "ok"})
 
         # 假 bot 进程（跑在 8081 对应的临时端口上）
+        async def fake_ready(_request):
+            return web.json_response({"status": "ok", "ready": True})
+
         bot_app = web.Application()
         bot_app.router.add_post("/webhook/bot1", fake_bot)
+        bot_app.router.add_get("/ready", fake_ready)
 
         # 让 router 的转发目标端口指向临时端口
         monkeypatch.setattr(run_mod, "bot_webhook_port", lambda i: 8081 if i == 1 else 8082)

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -166,3 +166,68 @@ class TestRouterRelay:
                     assert data["storage"]["delivery_outbox"]["files"] == 2
         finally:
             await runner.cleanup()
+
+
+class TestReadinessProbes:
+    """/live always answers; /ready aggregates bot-child readiness (503 while
+    any child is still warming, 200 once all are initialize()+start() done)."""
+
+    async def _serve(self, app, port):
+        from aiohttp import web
+        runner = web.AppRunner(app)
+        await runner.setup()
+        await web.TCPSite(runner, "127.0.0.1", port).start()
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_live_is_independent_of_child_warmup(self, monkeypatch):
+        from aiohttp import web
+        import aiohttp
+
+        # No bot children listening at all.
+        monkeypatch.setattr(run_mod, "bot_webhook_port", lambda i: 18100 + i)
+        router_app = run_mod.build_router_app([1])
+        runner = await self._serve(router_app, 18082)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get("http://127.0.0.1:18082/live") as resp:
+                    assert resp.status == 200
+                    assert (await resp.json())["kind"] == "live"
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_ready_503_while_child_not_ready_then_200(self, monkeypatch):
+        from aiohttp import web
+        import aiohttp
+
+        state = {"ready": False}
+
+        async def ready_handler(_request):
+            return web.json_response(
+                {"ready": state["ready"]},
+                status=200 if state["ready"] else 503,
+            )
+
+        child = web.Application()
+        child.router.add_get("/ready", ready_handler)
+
+        monkeypatch.setattr(run_mod, "bot_webhook_port", lambda i: 18111)
+        router_app = run_mod.build_router_app([1])
+        child_runner = await self._serve(child, 18111)
+        router_runner = await self._serve(router_app, 18083)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get("http://127.0.0.1:18083/ready") as resp:
+                    assert resp.status == 503
+                    data = await resp.json()
+                    assert data["bots"]["bot1"] is False
+
+                state["ready"] = True
+                async with session.get("http://127.0.0.1:18083/ready") as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data["bots"]["bot1"] is True
+        finally:
+            await router_runner.cleanup()
+            await child_runner.cleanup()

--- a/tests/test_webhook_secret.py
+++ b/tests/test_webhook_secret.py
@@ -1,0 +1,23 @@
+"""Stable webhook secret must survive restart so Telegram-delivered updates in
+the stop/restart window still validate (a random per-boot secret rejected them)."""
+import os
+import stat
+
+import main
+
+
+def test_webhook_secret_is_persisted_and_stable(tmp_path, monkeypatch):
+    db_path = tmp_path / "submissions.db"
+    monkeypatch.setattr(main, "DB_PATH", str(db_path))
+
+    first = main._load_or_create_persisted_webhook_secret()
+    assert first and len(first) >= 20
+
+    secret_file = tmp_path / "webhook.secret"
+    assert secret_file.read_text().strip() == first
+    mode = stat.S_IMODE(os.stat(secret_file).st_mode)
+    assert mode == 0o600
+
+    # A fresh process reading the same location gets the SAME secret.
+    second = main._load_or_create_persisted_webhook_secret()
+    assert second == first

--- a/utils/api_server.py
+++ b/utils/api_server.py
@@ -99,6 +99,15 @@ def _fields_target_id(payload) -> str:
     return str(payload.get("target_id", "")).strip()[:120]
 
 
+def _fields_work_type(payload) -> str:
+    value = str(payload.get("work_type", "")).strip().lower()
+    return value if value in ("illustration", "novel") else ""
+
+
+def _fields_pixiv_id(payload) -> str:
+    return str(payload.get("pixiv_id", "")).strip()[:32]
+
+
 def _clean_provenance_text(value, limit: int) -> str:
     """Bounded single-line provenance text.
 
@@ -294,21 +303,31 @@ def add_api_routes(web_app, application) -> None:
                     "user_id": user_id,
                     "username": username,
                 }
+                idem_key = _fields_idempotency_key(payload)
+                target_name = _fields_target_id(payload)
+                work_type = _fields_work_type(payload)
+                pixiv_id = _fields_pixiv_id(payload)
                 if API_REVIEW_REQUIRED:
                     from handlers.review import queue_review_from_file_ids
                     result = await queue_review_from_file_ids(
                         bot, media, documents,
-                        idempotency_key=_fields_idempotency_key(payload),
-                        target_id=_fields_target_id(payload),
+                        idempotency_key=idem_key,
+                        target_id=target_name,
                         source_label=_fields_source_label(payload),
                         source_ref=_fields_source_ref(payload),
                         scheduled_at=_fields_scheduled_at(payload),
+                        work_type=work_type,
                         **common,
                     )
                 else:
                     from handlers.publish import publish_from_file_ids
                     result = await publish_from_file_ids(
-                        bot, media, documents, **common,
+                        bot, media, documents,
+                        idempotency_key=idem_key,
+                        target_id=target_name,
+                        work_type=work_type,
+                        pixiv_id=pixiv_id,
+                        **common,
                     )
             except Exception as e:
                 action = "进入审核队列" if API_REVIEW_REQUIRED else "发布到频道"
@@ -410,6 +429,7 @@ def add_api_routes(web_app, application) -> None:
                     source_label=_fields_source_label(fields),
                     source_ref=_fields_source_ref(fields),
                     scheduled_at=_fields_scheduled_at(fields),
+                    work_type=_fields_work_type(fields),
                     **common,
                 )
             else:
@@ -623,6 +643,55 @@ def add_api_routes(web_app, application) -> None:
             return _ok(result.to_dict())
         return await _run_review_action(action)
 
+    async def delivery_lookup(request):
+        """Authenticated reconciliation lookup for a downstream work.
+        Lets the caller (e.g. PixivFlow doctor) ask 'did target X already
+        publish work Y?' without trusting a 2xx alone."""
+        token_row = await authenticate(_bearer(request) or "")
+        if token_row is None:
+            return _error(401, "invalid_token", "token 无效或已吊销")
+        q = request.query
+        target = (q.get("target") or "").strip()[:120]
+        work_type = (q.get("work_type") or "").strip().lower()
+        pixiv_id = (q.get("pixiv_id") or "").strip()[:32]
+        if work_type not in ("illustration", "novel") or not pixiv_id:
+            return _error(400, "invalid_query", "work_type (illustration|novel) 与 pixiv_id 必填")
+        from database.db_manager import get_db
+        cutoff = time.time() - (7 * 24 * 3600)
+        params = [pixiv_id, work_type] + ([target] if target else []) + [cutoff]
+        async with get_db() as conn:
+            cursor = await conn.execute(
+                "SELECT id, status, idempotency_key, target_id, published_message_id AS message_id, "
+                "pixiv_id, work_type, decided_at FROM pending_reviews "
+                "WHERE pixiv_id=? AND work_type=? "
+                + ("AND target_id=? " if target else "")
+                + "AND status='published' AND decided_at >= ? ORDER BY decided_at DESC LIMIT 1",
+                params,
+            )
+            review_row = await cursor.fetchone()
+            cursor = await conn.execute(
+                "SELECT id, status, idempotency_key, target_id, message_id, pixiv_id, work_type, created_at "
+                "FROM delivery_ledger WHERE pixiv_id=? AND work_type=? "
+                + ("AND target_id=? " if target else "")
+                + "AND status='published' AND created_at >= ? ORDER BY created_at DESC LIMIT 1",
+                ([pixiv_id, work_type, target, cutoff] if target else [pixiv_id, work_type, cutoff]),
+            )
+            ledger_row = await cursor.fetchone()
+
+        match = review_row or ledger_row
+        if match is None:
+            return _ok({"found": False, "target": target, "work_type": work_type, "pixiv_id": pixiv_id})
+        return _ok({
+            "found": True,
+            "target": target,
+            "work_type": work_type,
+            "pixiv_id": pixiv_id,
+            "delivery_status": match["status"],
+            "message_id": match["message_id"],
+            "matched_idempotency_key": match["idempotency_key"],
+            "source": "review" if review_row is not None else "direct",
+        })
+
     web_app.router.add_get("/api/v1/reviews/policy", review_policy)
     web_app.router.add_get("/api/v1/reviews", list_reviews)
     web_app.router.add_get("/api/v1/reviews/{review_id}", get_review)
@@ -635,6 +704,7 @@ def add_api_routes(web_app, application) -> None:
     web_app.router.add_get("/api/v1/health", health)
     web_app.router.add_get("/api/v1/me", me)
     web_app.router.add_post("/api/v1/submissions", create_submission)
+    web_app.router.add_get("/api/v1/deliveries/lookup", delivery_lookup)
     web_app.router.add_post("/api/v1/notifications", create_notification)
     logger.info("API 路由已注册: /api/v1/*")
     _ensure_upload_sweeper()

--- a/utils/polling_server.py
+++ b/utils/polling_server.py
@@ -32,8 +32,23 @@ def build_polling_app(application) -> web.Application:
             pass
         return web.json_response(payload)
 
+    async def live(_request: web.Request) -> web.Response:
+        # Process is up and serving its event loop. Never blocks on background init.
+        return web.json_response({"status": "ok", "kind": "live"})
+
+    async def ready(_request: web.Request) -> web.Response:
+        # The bot application has finished initialize()+start(); the PTB app
+        # exposes a running state once update processing is available.
+        running = bool(getattr(application, "running", False))
+        return web.json_response(
+            {"status": "ok" if running else "starting", "kind": "ready", "ready": running},
+            status=200 if running else 503,
+        )
+
     app = web.Application(client_max_size=API_CLIENT_MAX_BYTES)
     app.router.add_get("/health", health)
+    app.router.add_get("/live", live)
+    app.router.add_get("/ready", ready)
     if os.getenv("API_ENABLED", "true").lower() != "false":
         from utils.api_server import add_api_routes
 

--- a/utils/webhook_server.py
+++ b/utils/webhook_server.py
@@ -129,6 +129,18 @@ class WebhookServer:
             pass
         return web.json_response(payload)
     
+    async def live_handler(self, request: web.Request) -> web.Response:
+        from aiohttp import web as _web
+        return _web.json_response({"status": "ok", "kind": "live"})
+
+    async def ready_handler(self, request: web.Request) -> web.Response:
+        from aiohttp import web as _web
+        running = bool(getattr(self.application, "running", False)) if getattr(self, "application", None) else False
+        return _web.json_response(
+            {"status": "ok" if running else "starting", "kind": "ready", "ready": running},
+            status=200 if running else 503,
+        )
+
     async def start(self):
         """启动 Webhook 服务器"""
         from utils.api_server import API_CLIENT_MAX_BYTES
@@ -138,6 +150,8 @@ class WebhookServer:
         # 注册路由
         self.web_app.router.add_post(self.path, self.webhook_handler)
         self.web_app.router.add_get('/health', self.health_handler)
+        self.web_app.router.add_get('/live', self.live_handler)
+        self.web_app.router.add_get('/ready', self.ready_handler)
 
         # HTTP API（/api/v1，供外部项目自动化投稿）
         if os.getenv("API_ENABLED", "true").lower() != "false":


### PR DESCRIPTION
## 幂等直发 + 探针语义分离 + 快速启动（配合 PixivFlow reliability 收敛）

### 变更
- **幂等直发**：multipart 直发分支（`API_REVIEW_REQUIRED=false`）补齐幂等参数；响应信封区分 `reuse_reason`：`idempotent_replay`（同键重试，返回原 message_id）vs `duplicate_existing`（同作品不同意图历史重复，带 `matched_idempotency_key`）；对账查询供下游登记历史已发。
- **快速启动**：Whoosh 索引初始化/命令菜单后置到 READY 之后后台执行，冷启动回秒级。
- **稳定 webhook secret**：持久化到数据卷（0600），重启/唤醒后与已注册 secret 一致，消除 403 窗口。
- **探针分离**：`/live`（存活恒 200）、`/ready`（PTB initialize+start 完成才 200）、`/health`（容量/存储观测 + auto-stop 唤醒）；router 聚合子进程 `/ready` 且有界等待（30s），不再端口通就转发。

### 测试
486 passed（含 /ready 聚合 503→200、polling/webhook 就绪翻转、幂等 replay→duplicate 全链路）。

详见总 PR 描述（三仓）。