### PR TITLE
feat(release): 附版本号的 tar.gz/zip 归档产物

### DIFF
--- a/.release-policy.yml
+++ b/.release-policy.yml
@@ -27,7 +27,10 @@
     "required": [
       "telepost-linux-x64",
       "telepost-windows-x64.exe",
-      "telepost-macos-arm64"
+      "telepost-macos-arm64",
+      "telepost-*-linux-x64.tar.gz",
+      "telepost-*-macos-arm64.tar.gz",
+      "telepost-*-windows-x64.zip"
     ],
     "optional": []
   },

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -15,3 +15,22 @@ case "$RUNNER_OS" in
   Windows) asset=telepost-windows-x64.exe ;;
 esac
 cp dist/telepost "dist/release/$asset" 2>/dev/null || cp dist/telepost.exe "dist/release/$asset"
+# Versioned archive alongside the raw binary: a familiar double-click-to-extract
+# download with the version in the filename (bash + python exist on all 3 runners).
+python - "$asset" "$RELEASE_VERSION" <<'PY'
+import sys, tarfile, zipfile
+from pathlib import Path
+
+asset, version = sys.argv[1], sys.argv[2]
+src = Path("dist/release") / asset
+if asset.endswith(".exe"):
+    archive = Path(f"dist/release/telepost-{version}-windows-x64.zip")
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as z:
+        z.write(src, asset)
+else:
+    platform = "macos-arm64" if "macos" in asset else "linux-x64"
+    archive = Path(f"dist/release/telepost-{version}-{platform}.tar.gz")
+    with tarfile.open(archive, "w:gz") as t:
+        t.add(src, arcname=asset)
+print(archive)
+PY


### PR DESCRIPTION
## 动机
Release 目前只有三个无后缀裸二进制（\`telepost-linux-x64\` / \`telepost-macos-arm64\` / \`telepost-windows-x64.exe\`）。对普通用户，无后缀文件在浏览器/文件管理器里没有类型关联、文件名不含版本、不便归档保存。

## 变更
- \`scripts/build-release\`：保留裸二进制（脚本式直接运行、\`--version\` gate 不变），额外用 stdlib（\`tarfile\`/\`zipfile\`，无新依赖）生成：
  - \`telepost-<v>-linux-x64.tar.gz\`
  - \`telepost-<v>-macos-arm64.tar.gz\`
  - \`telepost-<v>-windows-x64.zip\`
- \`.release-policy.yml\`：3 个归档加入 required（glob 匹配），releasegraph asset gate 会自动做 tar/zip 完整性校验并纳入 SHA256SUMS。
- 下载页生成器按文件名推断平台，新归档自动出现在 docs/download.md，无需改脚本。

## 验证
- 本地用 releasegraph 的 \`collect_assets\` + \`write_checksums\` 实跑：6 产物全部通过，归档被正确校验，SHA256SUMS 6 行。
- 损坏的 tar.gz 被 asset gate 拒绝。
- 归档解包内容为对应的原始裸二进制。

下一个版本（2.16.2）发布后生效；2.16.1 不回溯。