### PR TITLE
test: 修复并发 SQLite 测试在 CI 上 flaky（450 != 500）

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -340,16 +340,24 @@ class TestPerformance:
         conn.close()
         
         # 并发写入函数
+        errors = []
+
         def write_data(thread_id, count):
-            conn = sqlite3.connect(db_path)
-            for i in range(count):
-                conn.execute(
-                    'INSERT INTO test_data (thread_id, value) VALUES (?, ?)',
-                    (thread_id, f'value_{i}')
-                )
-                conn.commit()
-            conn.close()
-        
+            try:
+                # busy_timeout：默认 5s 在 CI 高并发下会抛 "database is locked"，
+                # 而线程内异常不会在 join 时重抛，表现为行数静默变少（450 != 500）。
+                conn = sqlite3.connect(db_path, timeout=30)
+                conn.execute('PRAGMA busy_timeout=30000')
+                for i in range(count):
+                    conn.execute(
+                        'INSERT INTO test_data (thread_id, value) VALUES (?, ?)',
+                        (thread_id, f'value_{i}')
+                    )
+                    conn.commit()
+                conn.close()
+            except Exception as exc:
+                errors.append(exc)
+
         # 启动多个线程
         start_time = time.time()
         threads = []
@@ -360,7 +368,9 @@ class TestPerformance:
         
         for t in threads:
             t.join()
-        
+
+        assert not errors, f"并发写入失败: {errors!r}"
+
         end_time = time.time()
         
         # 验证性能


### PR DESCRIPTION
## 现象
release dry-run 中 \`test_concurrent_database_operations\` 间歇性失败：\`assert 450 == 500\`。

## 根因
- 10 线程各 50 条独立连接写同一个 SQLite，连接使用默认 5s busy timeout；CI runner 高负载时某线程提交撞上写锁，抛 \`database is locked\`。
- 线程内异常在 \`join()\` 时不会重抛——线程静默死亡，只剩 450 行，断言报出的是误导性的行数错误。

## 修复
- 写连接设置 \`timeout=30\` + \`PRAGMA busy_timeout=30000\`。
- 收集线程异常并在 join 后断言，真失败时报真实原因，不再伪装成行数缺失。

本地 10 线程 500 行 0.22s 稳定通过。仅测试代码变更。