### PR TITLE
feat: durable observability/audit for media decisions and review lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN npm install --prefix /opt/pixivflow "pixivflow@${PIXIVFLOW_VERSION}" \
 
 FROM python:3.11-slim AS runtime-base
 
+ARG APP_VERSION=dev
+ARG GIT_SHA=dev
+ARG BUILD_DATE=dev
+
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -39,6 +43,11 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.t
     && rm -rf /wheels
 
 COPY . .
+# Bake build identity for /version + /health. Same shape scripts/build-release
+# writes for PyInstaller bundles; the shared releasegraph workflow supplies the
+# build-args (APP_VERSION/GIT_SHA). Defaults keep a local `docker build` on dev.
+RUN printf 'RELEASE_VERSION = "%s"\nRELEASE_COMMIT = "%s"\nBUILD_DATE = "%s"\n' \
+        "${APP_VERSION}" "${GIT_SHA}" "${BUILD_DATE}" > /app/_release_version.py
 RUN mkdir -p logs data data/search_index \
     && chmod -R 755 logs data
 

--- a/database/db_manager.py
+++ b/database/db_manager.py
@@ -261,6 +261,39 @@ async def init_db():
                 "WHERE pixiv_id <> ''"
             )
 
+            # Append-only audit/observability log. pending_reviews remains the
+            # source of truth; these rows are evidence only and are pruned by
+            # cleanup_old_data (never while the referenced review is still open).
+            await conn.execute('''
+                CREATE TABLE IF NOT EXISTS audit_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts REAL NOT NULL,
+                    component TEXT DEFAULT 'telepost',
+                    event TEXT NOT NULL,
+                    review_id INTEGER,
+                    pixiv_id TEXT,
+                    work_type TEXT,
+                    target_id TEXT,
+                    idempotency_key TEXT,
+                    execution_id TEXT,
+                    actor TEXT,
+                    error_class TEXT,
+                    detail TEXT
+                )
+            ''')
+            await conn.execute(
+                'CREATE INDEX IF NOT EXISTS idx_audit_events_review '
+                'ON audit_events(review_id)'
+            )
+            await conn.execute(
+                'CREATE INDEX IF NOT EXISTS idx_audit_events_execution '
+                'ON audit_events(execution_id)'
+            )
+            await conn.execute(
+                'CREATE INDEX IF NOT EXISTS idx_audit_events_ts '
+                'ON audit_events(ts)'
+            )
+
             # published_posts 是频道现状，pending_reviews 是审核审计。频道消息被软删除时
             # 同步把对应审核记录从“曾发布”推进到“已删除”，避免把历史终态误当成
             # 当前仍在线的发布。触发器覆盖项目内所有软删除入口。
@@ -353,6 +386,31 @@ async def cleanup_old_data():
                         (review_cutoff,),
                     )
                     logger.info("已清理过期 API 通知幂等记录（保留 %d 天）", review_retention_days)
+
+        # Append-only audit: prune old rows, but keep every event attached to a
+        # still-open review (preparing/pending/publishing/failed) regardless of
+        # age. Unattached events (review_id IS NULL) follow the age cutoff.
+        audit_retention_days = int(os.getenv("AUDIT_RETENTION_DAYS", "30"))
+        if audit_retention_days > 0:
+            audit_cutoff = datetime.now().timestamp() - audit_retention_days * 86400
+            async with aiosqlite.connect(DB_PATH) as conn:
+                c = await conn.cursor()
+                await c.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='audit_events'"
+                )
+                has_audit = await c.fetchone()
+            if has_audit:
+                async with get_db() as conn:
+                    cursor = await conn.execute(
+                        "DELETE FROM audit_events WHERE ts < ? AND ("
+                        "review_id IS NULL OR review_id NOT IN ("
+                        "SELECT id FROM pending_reviews WHERE status IN "
+                        "('preparing', 'pending', 'publishing', 'failed')"
+                        "))",
+                        (audit_cutoff,),
+                    )
+                    logger.debug("已清理过期审计事件 %d 条（保留 %d 天）",
+                                 cursor.rowcount, audit_retention_days)
     except Exception as e:
         logger.error(f"清理过期数据失败: {e}")
 

--- a/handlers/publish.py
+++ b/handlers/publish.py
@@ -566,6 +566,25 @@ def _ledger_replay(row) -> dict:
     }
 
 
+async def _audit_duplicate_suppressed(row, reason, *, user_id, target_id,
+                                      work_type, pixiv_id):
+    """Durable audit for pre-send dedupe short-circuits (direct API path)."""
+    from telepost.observability import audit as audit_mod
+    matched = None
+    try:
+        matched = row.get("matched_idempotency_key")
+    except (AttributeError, TypeError):
+        matched = getattr(row, "idempotency_key", None)
+    await audit_mod.record_event(
+        "publish.duplicate_suppressed",
+        actor=f"telegram_user:{user_id}" if user_id else "api",
+        idempotency_key=getattr(row, "idempotency_key", None) or matched,
+        target_id=target_id or None, work_type=work_type or None,
+        pixiv_id=pixiv_id or None,
+        detail={"reuse_reason": reason, "matched_idempotency_key": matched},
+    )
+
+
 # Legacy ledger module-level helpers (kept as seams; delegate to repository).
 async def _ledger_find_by_key(idempotency_key: str):
     from telepost.storage.sqlite.ledger import DeliveryLedgerRepository
@@ -624,6 +643,10 @@ async def publish_from_files(bot, files, *, tags="", title="", note="", link="",
                 _os.remove(fobj["path"])
             except OSError:
                 pass
+        await _audit_duplicate_suppressed(
+            replay, "idempotent_replay", user_id=user_id, target_id=target_id,
+            work_type=work_type, pixiv_id=pid,
+        )
         return replay
     historical = await ledger.find_work(
         target_id, work_type, pid, PUBLISHED_DEDUP_WINDOW_SECONDS
@@ -635,6 +658,10 @@ async def publish_from_files(bot, files, *, tags="", title="", note="", link="",
             except OSError:
                 pass
         historical["reuse_reason"] = "duplicate_existing"
+        await _audit_duplicate_suppressed(
+            historical, "duplicate_existing", user_id=user_id,
+            target_id=target_id, work_type=work_type, pixiv_id=pid,
+        )
         return historical
 
     items = _items_from_dicts(
@@ -691,12 +718,20 @@ async def publish_from_file_ids(bot, media, documents, *, tags="", title="",
     ledger = _LedgerBridge()
     replay = await ledger.find_by_key(key)
     if replay is not None:
+        await _audit_duplicate_suppressed(
+            replay, "idempotent_replay", user_id=user_id, target_id=target_id,
+            work_type=work_type, pixiv_id=pid,
+        )
         return replay
     historical = await ledger.find_work(
         target_id, work_type, pid, PUBLISHED_DEDUP_WINDOW_SECONDS
     )
     if historical is not None and historical.get("matched_idempotency_key") != key:
         historical["reuse_reason"] = "duplicate_existing"
+        await _audit_duplicate_suppressed(
+            historical, "duplicate_existing", user_id=user_id,
+            target_id=target_id, work_type=work_type, pixiv_id=pid,
+        )
         return historical
 
     items = _items_from_dicts([

--- a/handlers/review.py
+++ b/handlers/review.py
@@ -156,7 +156,7 @@ async def _stage_file_ids(bot, media, documents, caption: str, spoiler: bool,
 
 async def _stage_local_files(bot, files, caption: str, spoiler: bool, message_ids):
     stager = _stager(bot)
-    staged_media, staged_documents, preview_ids = await stager.stage_local(
+    staged_media, staged_documents, preview_ids, _decisions = await stager.stage_local(
         files, caption=caption, spoiler=spoiler
     )
     message_ids.extend(preview_ids)

--- a/main.py
+++ b/main.py
@@ -277,7 +277,11 @@ async def main():
     """
     主函数 - 设置并启动机器人
     """
-    logger.info(f"启动TelePost机器人。版本: {CONFIG.get('VERSION', 'unknown')}")
+    from telepost.build_info import release_info
+    _build = release_info()
+    logger.info(
+        f"启动TelePost机器人。版本: {_build['version']} commit={_build['commit']}"
+    )
     logger.info(f"会话超时时间: {TIMEOUT_SECONDS}秒")
     
     # 初始化数据库

--- a/run.py
+++ b/run.py
@@ -110,6 +110,9 @@ def _directory_metrics(path: str, *, suffix: str | None = None) -> dict:
     if not os.path.isdir(path):
         return {"files": 0, "bytes": 0, "mb": 0.0}
     for root, _dirs, files in os.walk(path, followlinks=False):
+        # Archived/replayed manifests live under migrated/ and are no longer
+        # active outbox state; never count them.
+        _dirs[:] = [name for name in _dirs if name != "migrated"]
         for filename in files:
             if suffix and not filename.endswith(suffix):
                 continue
@@ -135,6 +138,10 @@ def _outbox_metrics(path: str) -> dict:
     oldest_mtime = None
     if os.path.isdir(path):
         for root, _dirs, files in os.walk(path, followlinks=False):
+            # The migrated/ archive holds manifests already replayed into the
+            # SQLite outbox (often with a non-null lastError); never count them
+            # or /health stays red forever.
+            _dirs[:] = [name for name in _dirs if name != "migrated"]
             for filename in files:
                 if not filename.endswith(".json"):
                     continue
@@ -452,7 +459,8 @@ def build_router_app(indices: list):
         await app[session_key].close()
 
     async def health(request):
-        payload = {"status": "ok", "service": "telepost", "bots": indices}
+        from telepost.build_info import release_info
+        payload = {"status": "ok", "bots": indices, **release_info()}
         try:
             import psutil
             procs = _process_rss_snapshot()
@@ -471,6 +479,10 @@ def build_router_app(indices: list):
         except Exception:
             pass
         return web.json_response(payload)
+
+    async def version(_request):
+        from telepost.build_info import release_info
+        return web.json_response(release_info())
 
     # The router never buffers submission bodies. The explicit size ceiling is
     # still useful for malformed clients and matches TelePost's 500 MiB API cap
@@ -501,6 +513,7 @@ def build_router_app(indices: list):
     app.router.add_get("/health", health)
     app.router.add_get("/live", live)
     app.router.add_get("/ready", ready)
+    app.router.add_get("/version", version)
 
     def make_relay(index: int, strip: str | None, prepend: str = "", port_override: int | None = None):
         async def relay(request):
@@ -706,11 +719,10 @@ def run_multi(indices: list) -> None:
 
 def main():
     if "--version" in sys.argv:
-        try:
-            from _release_version import RELEASE_VERSION, RELEASE_COMMIT, BUILD_DATE
-        except ImportError:
-            RELEASE_VERSION = RELEASE_COMMIT = BUILD_DATE = "dev"
-        print(f"telepost {RELEASE_VERSION} commit={RELEASE_COMMIT} date={BUILD_DATE}")
+        from telepost.build_info import release_info
+        info = release_info()
+        print(f"telepost {info['version']} commit={info['commit']} "
+              f"date={info['build_date']}")
         return
     if _FROZEN:
         # 冻结版以 exe 所在目录为工作目录：data/ logs/ config.ini 都落在这里

--- a/services/review_service.py
+++ b/services/review_service.py
@@ -14,6 +14,7 @@ that a stale reclaim already moved again.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import logging
@@ -24,6 +25,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from telepost.observability.errors import classify as classify_error
 from telepost.storage.sqlite.reviews import ReviewRepository
 
 logger = logging.getLogger(__name__)
@@ -262,6 +264,59 @@ def _audit(action: str, review_id: int, actor: Any, result: str, **extra) -> Non
     }
     payload.update({k: v for k, v in extra.items() if v is not None})
     logger.info("review audit %s", payload)
+    _schedule_durable_audit(action, review_id, actor, source, payload)
+
+
+def _schedule_durable_audit(action: str, review_id: int, actor: Any,
+                            source: str, payload: dict) -> None:
+    """Fire-and-forget durable twin of the stdout audit line."""
+    from telepost.observability import audit as audit_mod
+
+    event = {
+        "set_spoiler": "review.set_spoiler",
+        "toggle_spoiler": "review.toggle_spoiler",
+    }.get(action, f"review.{action}")
+    # approve/reject durable events are emitted explicitly by the service with
+    # full row context (typed error class, execution id).
+    if action in ("approve", "reject"):
+        return
+    fields = {
+        "review_id": int(review_id) if review_id is not None else None,
+        "actor": f"telegram_user:{actor}" if isinstance(actor, int) else (
+            str(actor) if actor else ("mcp" if source == "mcp" else "api")
+        ),
+        "detail": {k: v for k, v in payload.items()
+                   if k not in {"event", "review_id", "actor"}},
+    }
+    try:
+        asyncio.get_running_loop().create_task(
+            audit_mod.record_event(event, **fields)
+        )
+    except RuntimeError:
+        pass
+
+
+async def _record_review_event(event: str, row, actor: Any, *,
+                               error_class: Optional[str] = None,
+                               detail: Optional[Dict[str, Any]] = None) -> None:
+    from telepost.observability import audit as audit_mod
+
+    fields: Dict[str, Any] = {
+        "review_id": int(row["id"]),
+        "actor": f"telegram_user:{actor}" if isinstance(actor, int) else (
+            str(actor) if actor else "api"
+        ),
+        "pixiv_id": row["pixiv_id"] or None,
+        "work_type": row["work_type"] or None,
+        "target_id": row["target_id"] or None,
+        "idempotency_key": row["idempotency_key"] or None,
+        "execution_id": audit_mod.execution_id_from_ref(row["source_ref"]),
+    }
+    if error_class:
+        fields["error_class"] = error_class
+    if detail:
+        fields["detail"] = detail
+    await audit_mod.record_event(event, **fields)
 
 
 class ReviewService:
@@ -403,6 +458,10 @@ class ReviewService:
                                review_id, exc_info=True)
         _audit("reject", int(review_id), actor, "ok",
                source=source, reason=safe_reason or None)
+        await _record_review_event(
+            "review.rejected", row, actor,
+            detail={"reason": safe_reason} if safe_reason else None,
+        )
         return ActionResult(int(review_id), "rejected", False)
 
     def failure_hint(self, error: BaseException) -> str:
@@ -436,6 +495,10 @@ class ReviewService:
             raise ReviewNotFoundError("审核记录不存在")
         if not claimed:
             if row["status"] == "published":
+                await _record_review_event(
+                    "publish.duplicate_suppressed", row, actor,
+                    detail={"reuse_reason": "already_published"},
+                )
                 return ActionResult(
                     review_id, "published", True,
                     row["published_message_id"], None,
@@ -455,6 +518,7 @@ class ReviewService:
                 logger.debug("审核 claim UI 通知失败: review_id=%s", review_id,
                              exc_info=True)
 
+        await _record_review_event("publish.started", row, actor)
         try:
             result = await self._publish(bot, row, current_spoiler)
         except Exception as error:
@@ -462,6 +526,11 @@ class ReviewService:
             await self._repo.mark_failed(review_id, str(error))
             _audit("approve", review_id, actor, "failed",
                    source=source, error=str(error)[:120])
+            await _record_review_event(
+                "review.failed", row, actor,
+                error_class=classify_error(error),
+                detail={"error": str(error)[:200]},
+            )
             raise PublishFailedError(
                 str(error)[:200],
                 retry_hint=self.failure_hint(error),
@@ -497,6 +566,14 @@ class ReviewService:
                 logger.warning("通知聊天投稿人通过结果失败: review_id=%s",
                                review_id, exc_info=True)
         _audit("approve", review_id, actor, "published", source=source)
+        await _record_review_event(
+            "review.approved", row, actor,
+            detail={"message_id": result.get("message_id")},
+        )
+        await _record_review_event(
+            "publish.completed", row, actor,
+            detail={"message_id": result.get("message_id")},
+        )
         return ActionResult(
             review_id, "published", False,
             result.get("message_id"), result.get("link"),

--- a/telepost/application/publication.py
+++ b/telepost/application/publication.py
@@ -28,6 +28,8 @@ from ..domain.delivery import (
     DeliveryResult,
     MediaItem,
 )
+from ..observability import audit
+from ..observability.errors import classify as classify_error
 from ..storage.sqlite.ledger import DeliveryLedgerRepository, LedgerEntry
 
 logger = logging.getLogger(__name__)
@@ -142,6 +144,11 @@ class PublicationService:
         from ..domain.delivery import ReplyMode
 
         pid = (command.pixiv_id or "").strip()
+        event_fields = self._event_fields(command, key)
+        # Review-approved publishes use review:<id>:<original> keys. Their
+        # publish.* audit is owned by ReviewService (which keeps the durable
+        # event linked to the review row); emitting here too would double it.
+        audit_publish = not (key.startswith("review:") and event_fields["review_id"])
 
         replay = await self._ledger.find_by_key(key)
         if replay is not None:
@@ -162,6 +169,8 @@ class PublicationService:
             reply_to_message_id=command.reply_to_message_id,
             album_size=command.album_size,
         )
+        if audit_publish:
+            await audit.record_event("publish.started", **event_fields)
         result = await self._delivery.deliver(request)
 
         if result.is_uncertain:
@@ -175,13 +184,21 @@ class PublicationService:
                 error=getattr(result, "error", None),
             )
         if not result.ok or result.main_message is None:
+            error = getattr(result, "error", None)
+            if audit_publish:
+                await audit.record_event(
+                    "publish.failed",
+                    error_class=classify_error(error),
+                    detail={"reason": result.reason or "delivery failed"},
+                    **event_fields,
+                )
             return PublicationOutcome(
                 status="failed",
                 reason=result.reason or "delivery failed",
                 retryable=result.retryable,
                 known_messages=result.known_messages,
                 delivery_status="failed",
-                error=getattr(result, "error", None),
+                error=error,
             )
 
         main = result.main_message
@@ -217,6 +234,13 @@ class PublicationService:
                     delivery_status="uncertain",
                 )
 
+        if audit_publish:
+            await audit.record_event(
+                "publish.completed",
+                detail={"message_id": main.message_id,
+                        "media": media_count, "documents": document_count},
+                **event_fields,
+            )
         return PublicationOutcome(
             status="published",
             message_id=main.message_id,
@@ -225,7 +249,46 @@ class PublicationService:
             document_count=document_count,
         )
 
+    @staticmethod
+    def _event_fields(command: PublishCommand, key: str) -> dict:
+        # Review-approved publishes use keys shaped review:<id>:<original>.
+        review_id = None
+        parts = key.split(":", 2)
+        if len(parts) == 3 and parts[0] == "review" and parts[1].isdigit():
+            review_id = int(parts[1])
+        return {
+            "review_id": review_id,
+            "pixiv_id": (command.pixiv_id or "").strip() or None,
+            "work_type": command.work_type or None,
+            "target_id": command.target_id or None,
+            "idempotency_key": key or None,
+            "actor": f"telegram_user:{command.user_id}" if command.user_id else "api",
+        }
+
     def _replay(self, entry: LedgerEntry, *, reason: str) -> PublicationOutcome:
+        key = entry.idempotency_key or ""
+        review_id = None
+        parts = key.split(":", 2)
+        is_review_key = (
+            len(parts) == 3 and parts[0] == "review" and parts[1].isdigit()
+        )
+        if is_review_key:
+            review_id = int(parts[1])
+        # review-keyed replays are audited by ReviewService (or short-circuited
+        # before the publisher entirely) — never double-emit from the service.
+        if not is_review_key:
+            try:
+                asyncio.get_running_loop().create_task(audit.record_event(
+                    "publish.duplicate_suppressed",
+                    pixiv_id=entry.pixiv_id or None,
+                    work_type=entry.work_type or None,
+                    target_id=entry.target_id or None,
+                    idempotency_key=key or None,
+                    detail={"reuse_reason": reason,
+                            "matched_idempotency_key": entry.idempotency_key},
+                ))
+            except RuntimeError:
+                pass
         message_id = entry.message_id or 0
         return PublicationOutcome(
             status="published",

--- a/telepost/application/review_queue.py
+++ b/telepost/application/review_queue.py
@@ -20,11 +20,37 @@ import re
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Awaitable, Callable, List, Optional, Protocol, Tuple
+from typing import Any, Awaitable, Callable, List, Optional, Protocol, Tuple
 
+from ..observability import audit
+from ..observability.errors import classify as classify_error
 from ..storage.sqlite.reviews import NewReview, ReviewRepository
 
 logger = logging.getLogger(__name__)
+
+
+def _actor(user_id: Any = None) -> str:
+    return f"telegram_user:{user_id}" if user_id else "api"
+
+
+def _common(command: QueueCommand) -> dict:
+    return {
+        "idempotency_key": command.idempotency_key or None,
+        "execution_id": audit.execution_id_from_ref(command.source_ref),
+        "actor": _actor(command.user_id),
+        "target_id": command.target_id or None,
+        "work_type": command.work_type or None,
+        "pixiv_id": command.pixiv_id or None,
+    }
+
+
+async def _record(event: str, command: QueueCommand, **fields) -> None:
+    payload = dict(_common(command))
+    payload.update(fields)
+    await audit.record_event(
+        event, **{k: v for k, v in payload.items()
+                  if v is not None or k in ("review_id", "detail")}
+    )
 
 PUBLISHED_DEDUP_WINDOW_SECONDS = 7 * 86400
 _PIXIV_ID_RE = re.compile(r"pixiv\.net/(?:artworks/|novel/show\.php\?id=)(\d+)")
@@ -65,7 +91,7 @@ class QueueCommand:
 
 class StagingPort(Protocol):
     async def stage_local(self, files, *, caption: str, spoiler: bool
-                          ) -> Tuple[list, list, List[int]]: ...
+                          ) -> Tuple[list, list, List[int], list]: ...
 
     async def stage_file_ids(self, media, documents, *, caption: str, spoiler: bool
                              ) -> Tuple[list, list, List[int]]: ...
@@ -119,6 +145,12 @@ class ReviewQueueService:
                     await self._repo.backfill_target(existing["id"], command.target_id)
                     existing = await self._repo.get(existing["id"])
                 await stager.notify_reused(existing)
+                await _record(
+                    "submission.duplicate", command,
+                    review_id=existing["id"],
+                    detail={"reused_id": existing["id"],
+                            "status": existing["status"]},
+                )
                 return self.result_from_row(existing, reused=True)
             finally:
                 if is_local:
@@ -147,16 +179,26 @@ class ReviewQueueService:
         except ReusedReview as reused:
             if is_local:
                 await stager.cleanup_files(files)
+            reused_id = (reused.result or {}).get("review_id")
+            if reused_id is not None:
+                await _record(
+                    "submission.duplicate", command, review_id=reused_id,
+                    detail={"reused_id": reused_id},
+                )
             return reused.result
 
+        await _record("review.created", command, review_id=review_id)
+
+        media_decisions: list = []
         try:
             # Pass the id list in-out: when staging fails mid-way, ids of
             # already-uploaded previews survive for rollback deletion.
             if is_local:
-                staged_media, staged_documents, preview_ids = await stager.stage_local(
-                    files, caption=caption, spoiler=command.spoiler,
-                    message_ids=preview_ids,
-                )
+                staged_media, staged_documents, preview_ids, media_decisions = \
+                    await stager.stage_local(
+                        files, caption=caption, spoiler=command.spoiler,
+                        message_ids=preview_ids,
+                    )
             else:
                 staged_media, staged_documents, preview_ids = await stager.stage_file_ids(
                     media or [], documents or [],
@@ -169,15 +211,25 @@ class ReviewQueueService:
             await self._repo.mark_preparation_failed(
                 review_id, message, clear_previews=True
             )
+            await _record(
+                "review.failed", command, review_id=review_id,
+                error_class=classify_error(exc),
+                detail={"stage": "preview_staging", "error": message[:200]},
+            )
             if is_local:
                 await stager.cleanup_files(files)
             if message.startswith("返回消息数") and "与文件数" in message:
                 raise RuntimeError(message.replace("返回消息数", "消息数", 1))
             raise
-        except Exception:
+        except Exception as exc:
             await stager.delete_preview_messages(preview_ids)
             await self._repo.mark_preparation_failed(
                 review_id, "preview staging failed", clear_previews=True
+            )
+            await _record(
+                "review.failed", command, review_id=review_id,
+                error_class=classify_error(exc),
+                detail={"stage": "preview_staging", "error": str(exc)[:200]},
             )
             if is_local:
                 await stager.cleanup_files(files)
@@ -190,19 +242,39 @@ class ReviewQueueService:
             )
             if not staged:
                 raise RuntimeError("审核记录在预览完成前被并发修改")
+            await _record(
+                "review.preview_staged", command, review_id=review_id,
+                detail={"media": len(staged_media),
+                        "documents": len(staged_documents),
+                        "preview_messages": len(preview_ids)},
+            )
+            if is_local and media_decisions:
+                await _record(
+                    "media.prepared", command, review_id=review_id,
+                    detail={"items": media_decisions},
+                )
             control_id = await stager.send_control_message_id(
                 review_id=review_id, command=command,
                 preview_message_ids=preview_ids,
                 media_count=len(staged_media),
                 document_count=len(staged_documents),
             )
+            await _record("review.control_created", command,
+                          review_id=review_id,
+                          detail={"control_message_id": control_id})
             if not await self._repo.finalize_control(review_id, control_id):
                 await stager.delete_preview_messages([control_id])
                 raise RuntimeError("审核控制消息无法绑定到记录")
+            await _record("review.pending", command, review_id=review_id)
         except Exception as exc:
             await stager.delete_preview_messages(preview_ids)
             await self._repo.mark_preparation_failed(
                 review_id, str(exc), clear_previews=True
+            )
+            await _record(
+                "review.failed", command, review_id=review_id,
+                error_class=classify_error(exc),
+                detail={"stage": "control_message", "error": str(exc)[:200]},
             )
             raise
         finally:
@@ -300,6 +372,23 @@ class ReviewQueueService:
             media = _loads(row["media_json"])
             documents = _loads(row["documents_json"])
             ready = bool(media or documents)
+            command = _command_from_row(row)
+
+            async def record_reconciled(action, *, error=None):
+                await audit.record_event(
+                    "review.reconciled", review_id=row["id"],
+                    actor="system_reconciler",
+                    pixiv_id=row["pixiv_id"] or None,
+                    work_type=row["work_type"] or None,
+                    target_id=row["target_id"] or None,
+                    idempotency_key=row["idempotency_key"] or None,
+                    execution_id=audit.execution_id_from_ref(row["source_ref"]),
+                    **({"error_class": "reconciliation_failed"}
+                       if action == "manual_intervention_required" else {}),
+                    detail=({"action": action} if error is None
+                            else {"action": action, "error": error}),
+                )
+
             if not ready and preview_ids:
                 await stager.delete_preview_messages(preview_ids)
                 preview_ids = []
@@ -307,7 +396,7 @@ class ReviewQueueService:
                     row["id"], "preview preparation interrupted by process restart",
                     clear_previews=True,
                 )
-            command = _command_from_row(row)
+                await record_reconciled("orphan_preview_removed")
             try:
                 control_id = await stager.send_control_message_id(
                     review_id=row["id"], command=command,
@@ -318,10 +407,14 @@ class ReviewQueueService:
                     row["id"], control_id, ready=ready
                 ):
                     repaired += 1
-            except Exception:
+                    await record_reconciled("control_message_recreated")
+            except Exception as exc:
                 logger.warning(
                     "修复审核控制消息失败: review_id=%s", row["id"],
                     exc_info=True,
+                )
+                await record_reconciled(
+                    "manual_intervention_required", error=str(exc)[:200]
                 )
         return repaired
 

--- a/telepost/build_info.py
+++ b/telepost/build_info.py
@@ -1,0 +1,33 @@
+"""Single committed source of build identity.
+
+The release pipeline (PyInstaller bundle via scripts/build-release, or the
+Docker image) may additionally drop a top-level ``_release_version.py`` next
+to the entry points; when present it overrides these committed defaults.
+"""
+
+RELEASE_VERSION = "2.16.1"
+RELEASE_COMMIT = "dev"
+BUILD_DATE = "dev"
+SERVICE = "telepost"
+
+
+def release_info() -> dict:
+    """Return {service, version, commit, build_date}, preferring build-time file."""
+    try:
+        import _release_version  # type: ignore
+        return {
+            "service": SERVICE,
+            "version": getattr(_release_version, "RELEASE_VERSION", RELEASE_VERSION)
+            or RELEASE_VERSION,
+            "commit": getattr(_release_version, "RELEASE_COMMIT", RELEASE_COMMIT)
+            or RELEASE_COMMIT,
+            "build_date": getattr(_release_version, "BUILD_DATE", BUILD_DATE)
+            or BUILD_DATE,
+        }
+    except Exception:
+        return {
+            "service": SERVICE,
+            "version": RELEASE_VERSION,
+            "commit": RELEASE_COMMIT,
+            "build_date": BUILD_DATE,
+        }

--- a/telepost/observability/__init__.py
+++ b/telepost/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal observability: durable audit events, error classification, redaction."""

--- a/telepost/observability/audit.py
+++ b/telepost/observability/audit.py
@@ -1,0 +1,123 @@
+"""Durable, append-only audit events backed by ``audit_events``.
+
+Every call is best-effort: a database failure is logged and swallowed so
+auditing can never break the submission/publish paths. The review row in
+``pending_reviews`` stays the source of truth; this table is evidence only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Optional
+
+from database import db_manager
+from .redact import sanitize_detail
+
+logger = logging.getLogger(__name__)
+
+_DETAIL_MAX_CHARS = 4000
+_COLUMNS = (
+    "ts", "component", "event", "review_id", "pixiv_id", "work_type",
+    "target_id", "idempotency_key", "execution_id", "actor",
+    "error_class", "detail",
+)
+
+
+def detail_value(raw: Any) -> Any:
+    """Parse a stored JSON detail; pass through already-decoded values."""
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return raw
+    return raw
+
+
+def execution_id_from_ref(source_ref: Optional[str]) -> Optional[str]:
+    """Extract a PixivFlow executionId from a source_ref (JSON or bare value)."""
+    if not source_ref:
+        return None
+    text = str(source_ref).strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return text[:240]
+    if isinstance(parsed, dict):
+        value = parsed.get("executionId") or parsed.get("execution_id")
+        return str(value)[:240] if value else None
+    return text[:240]
+
+
+def _encode_detail(detail: Any) -> Optional[str]:
+    if detail is None:
+        return None
+    try:
+        text = json.dumps(
+            sanitize_detail(detail), ensure_ascii=False,
+            separators=(",", ":"), default=str,
+        )
+    except (TypeError, ValueError):
+        return None
+    return text[:_DETAIL_MAX_CHARS]
+
+
+async def record_event(event: str, **fields: Any) -> None:
+    """Append one audit event. Never raises (logs a warning on failure)."""
+    values = {name: None for name in _COLUMNS}
+    values["component"] = "telepost"
+    values["ts"] = float(fields.pop("ts", None) or time.time())
+    values["event"] = str(event)
+    for name in _COLUMNS:
+        if name in fields:
+            values[name] = fields[name]
+    values["detail"] = _encode_detail(fields.get("detail") if "detail" in fields
+                                      else values["detail"])
+    try:
+        async with db_manager.get_db() as conn:
+            await conn.execute(
+                f"INSERT INTO audit_events ({', '.join(_COLUMNS)}) "
+                f"VALUES ({', '.join('?' for _ in _COLUMNS)})",
+                tuple(values[name] for name in _COLUMNS),
+            )
+    except Exception as exc:  # auditing must never break the business path
+        logger.warning("audit event not persisted: event=%s error=%s", event, exc)
+
+
+async def list_events(*, review_id: Optional[int] = None,
+                      execution_id: Optional[str] = None,
+                      limit: int = 100) -> list[dict]:
+    """Return audit events newest-first, optionally filtered by review/execution."""
+    clauses, params = [], []
+    if review_id is not None:
+        clauses.append("review_id=?")
+        params.append(int(review_id))
+    if execution_id is not None:
+        clauses.append("execution_id=?")
+        params.append(str(execution_id))
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    params.append(max(1, min(int(limit), 1000)))
+    try:
+        async with db_manager.get_db() as conn:
+            cur = await conn.execute(
+                f"SELECT * FROM audit_events{where} "
+                "ORDER BY ts DESC, id DESC LIMIT ?",
+                tuple(params),
+            )
+            rows = await cur.fetchall()
+    except Exception as exc:
+        logger.warning("audit events not readable: %s", exc)
+        return []
+    events = []
+    for row in rows:
+        item = dict(row)
+        raw = item.get("detail")
+        if raw:
+            try:
+                item["detail"] = json.loads(raw)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                pass
+        events.append(item)
+    return events

--- a/telepost/observability/cli.py
+++ b/telepost/observability/cli.py
@@ -1,0 +1,111 @@
+"""Read-only observability CLI: ``reviews inspect <id> [--bot N]``.
+
+Resolves the SQLite DB the same way the migration/cleanup scripts do:
+``config.settings.DB_PATH`` (which honors ``DB_PATH``/``BOTN_DB_PATH`` env) with
+the multi-bot default ``data/botN/submissions.db``. Never writes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from typing import Optional
+
+
+def resolve_db_path(bot: Optional[int]) -> str:
+    if bot is not None:
+        # Mirror run.build_bot_env: BOT{n}_DB_PATH overrides the per-bot
+        # default; an explicit --bot selects the per-bot data directory.
+        return os.getenv(f"BOT{bot}_DB_PATH", f"data/bot{bot}/submissions.db")
+    if os.getenv("DB_PATH"):
+        return os.environ["DB_PATH"]
+    try:
+        from config.settings import DB_PATH
+        return DB_PATH
+    except Exception:
+        return "data/submissions.db"
+
+
+def _connect(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{os.path.abspath(path)}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _print_row(row: Optional[sqlite3.Row]) -> None:
+    if row is None:
+        print("review: <not found>")
+        return
+    print("review:")
+    for key in row.keys():
+        print(f"  {key}: {row[key]}")
+
+
+def inspect_review(db_path: str, review_id: int) -> int:
+    if not os.path.exists(db_path):
+        print(f"database not found: {db_path}", file=sys.stderr)
+        return 2
+    with _connect(db_path) as conn:
+        review = conn.execute(
+            "SELECT * FROM pending_reviews WHERE id=?", (review_id,)
+        ).fetchone()
+        _print_row(review)
+
+        print("\naudit_events (newest first):")
+        try:
+            events = conn.execute(
+                "SELECT * FROM audit_events WHERE review_id=? "
+                "ORDER BY ts DESC, id DESC",
+                (review_id,),
+            ).fetchall()
+        except sqlite3.Error as exc:
+            print(f"  <audit_events unavailable: {exc}>")
+            events = []
+        if not events:
+            print("  <none>")
+        for event in events:
+            detail = event["detail"]
+            try:
+                detail = json.dumps(json.loads(detail), ensure_ascii=False)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                pass
+            print(
+                f"  [{event['ts']}] {event['event']} actor={event['actor']} "
+                f"error_class={event['error_class']} detail={detail}"
+            )
+
+        print("\ndelivery_ledger:")
+        ledger = None
+        if review is not None and review["idempotency_key"]:
+            ledger = conn.execute(
+                "SELECT * FROM delivery_ledger WHERE idempotency_key=?",
+                (f"review:{review_id}:{review['idempotency_key']}",),
+            ).fetchone()
+        if ledger is None:
+            print("  <none>")
+        else:
+            for key in ledger.keys():
+                print(f"  {key}: {ledger[key]}")
+    return 0 if review is not None else 1
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(prog="telepost.observability.cli")
+    sub = parser.add_subparsers(dest="resource", required=True)
+    reviews = sub.add_parser("reviews")
+    review_sub = reviews.add_subparsers(dest="action", required=True)
+    inspect_parser = review_sub.add_parser("inspect")
+    inspect_parser.add_argument("review_id", type=int)
+    inspect_parser.add_argument("--bot", type=int, default=None)
+
+    args = parser.parse_args(argv)
+    if args.resource == "reviews" and args.action == "inspect":
+        return inspect_review(resolve_db_path(args.bot), args.review_id)
+    parser.error("unsupported command")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/telepost/observability/errors.py
+++ b/telepost/observability/errors.py
@@ -1,0 +1,51 @@
+"""Map exceptions (and optional HTTP statuses) to stable error class strings.
+
+Specific exception types win over a coarse HTTP status, so an upstream 502
+wrapping a timeout keeps the true cause.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+def classify(exc: Optional[BaseException], status: Optional[int] = None) -> str:
+    if exc is not None:
+        module = type(exc).__module__ or ""
+        name = type(exc).__name__ or ""
+
+        if module.startswith("telegram.error") or module.startswith("telegram."):
+            if name in ("TimedOut",):
+                return "network_timeout"
+            if name in ("RetryAfter", "TelegramRetryAfter"):
+                return "rate_limited"
+            if name == "BadRequest":
+                return "telegram_send_failed"
+
+        try:
+            import aiosqlite
+            if isinstance(exc, aiosqlite.Error):
+                return "database_failed"
+        except ImportError:  # pragma: no cover
+            pass
+
+        code = str(getattr(exc, "code", "") or "")
+        if code == "duplicate_publication":
+            return "duplicate"
+        text = f"{name} {exc}".lower()
+        if "decode" in text and "budget" in text:
+            return "media_decode_budget_exceeded"
+        if module.startswith("PIL.") or name in (
+            "UnidentifiedImageError", "DecompressionBombError"
+        ):
+            return "media_processing_failed"
+
+    if isinstance(status, int):
+        if status == 409:
+            return "idempotency_conflict"
+        if status == 429:
+            return "rate_limited"
+        if 500 <= status < 600:
+            return "remote_5xx"
+        if 400 <= status < 500:
+            return "remote_4xx"
+    return "internal_error"

--- a/telepost/observability/redact.py
+++ b/telepost/observability/redact.py
@@ -1,0 +1,76 @@
+"""Best-effort secret redaction for logs and audit details.
+
+Stdlib only. The rules deliberately stay simple: miss an obscure leak rather
+ than build a secret-detection engine.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_MASK = "***"
+
+# Telegram bot tokens look like 123456789:AA... (8-10 digit bot id, colon,
+# 35-ish base64url-ish chars).
+_BOT_TOKEN_RE = re.compile(r"\d{6,}:[A-Za-z0-9_-]{20,}")
+_BEARER_RE = re.compile(r"(?i:\bBearer\s+)[A-Za-z0-9._\-]+")
+# token=/secret=/password= URL/form params.
+_PARAM_RE = re.compile(
+    r"(?i:((?:^|[?;&\s])(?:token|secret|password|api[_-]?key)\s*=\s*))[^&\s;\"']+"
+)
+
+_SENSITIVE_HEADERS = {
+    "authorization",
+    "cookie",
+    "x-telegram-bot-api-secret-token",
+}
+_SENSITIVE_KEY_PARTS = ("token", "secret", "password", "api_key", "apikey")
+
+
+def redact_text(value: str) -> str:
+    """Mask bot tokens, Bearer credentials and secret-ish params in a string."""
+    if not isinstance(value, str):
+        value = str(value)
+    value = _BOT_TOKEN_RE.sub(_MASK, value)
+    value = _BEARER_RE.sub(lambda m: m.group(0).split()[0] + " " + _MASK, value)
+    value = _PARAM_RE.sub(lambda m: m.group(1) + _MASK, value)
+    return value
+
+
+def redact_headers(headers: Any) -> dict:
+    """Return a copy of a headers mapping with sensitive values masked."""
+    try:
+        items = headers.items()
+    except AttributeError:
+        return {}
+    out = {}
+    for key, value in items:
+        lname = str(key).lower()
+        if lname in _SENSITIVE_HEADERS or any(
+            part in lname for part in _SENSITIVE_KEY_PARTS
+        ):
+            out[key] = _MASK
+        else:
+            out[key] = redact_text(str(value))
+    return out
+
+
+def sanitize_detail(obj: Any) -> Any:
+    """Recursively mask sensitive keys and redact string values."""
+    if isinstance(obj, dict):
+        return {
+            key: _MASK if _is_sensitive_key(key) else sanitize_detail(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, (list, tuple)):
+        return [sanitize_detail(value) for value in obj]
+    if isinstance(obj, str):
+        return redact_text(obj)
+    return obj
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    lname = str(key).lower()
+    return lname in _SENSITIVE_HEADERS or any(
+        part in lname for part in _SENSITIVE_KEY_PARTS
+    )

--- a/telepost/telegram/delivery/preparation.py
+++ b/telepost/telegram/delivery/preparation.py
@@ -10,12 +10,14 @@ Pure filesystem + Pillow, no PTB imports.
 """
 from __future__ import annotations
 
+import json
 import logging
+import mimetypes
 import os
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from ...domain.delivery import LocalFile, MediaItem, MediaKind
 
@@ -71,6 +73,47 @@ class PreparedMedia:
     kind: MediaKind
     reason: PreparationDecision
     temporary: bool = False
+    decision: Optional[Dict[str, Any]] = None
+
+
+def log_media_decision(payload: Dict[str, Any]) -> None:
+    """Emit the single structured decision line for one classified item."""
+    logger.info("media decision %s", json.dumps(payload, ensure_ascii=False,
+                                                default=str))
+
+
+def _decision_payload(path: str, *, size: int, decision: str, reason: str,
+                      probe: Optional[MediaProbe] = None,
+                      estimate: Optional[MediaResourceEstimate] = None,
+                      policy: Optional["MediaPreparationPolicy"] = None,
+                      delivery: Optional[str] = None,
+                      preview_available: bool = False) -> Dict[str, Any]:
+    mime = mimetypes.guess_type(path)[0] or ""
+    payload: Dict[str, Any] = {
+        "filename": os.path.basename(path),
+        "mime": mime,
+        "file_bytes": size,
+        "width": probe.width if probe else None,
+        "height": probe.height if probe else None,
+        "mode": probe.mode if probe else None,
+        "estimated_decode_bytes": (
+            estimate.estimated_decode_bytes if estimate else None
+        ),
+        "decode_budget_bytes": (
+            policy.decode_budget_bytes if policy else IMAGE_DECODE_BUDGET_BYTES
+        ),
+        "telegram_photo_limit": policy.max_bytes if policy else PHOTO_MAX_BYTES,
+        "preview_available": preview_available,
+        "decision": decision,
+        "reason": reason,
+        "original_bytes": size,
+    }
+    if delivery and delivery != path:
+        try:
+            payload["prepared_bytes"] = os.stat(delivery).st_size
+        except OSError:
+            pass
+    return payload
 
 
 def probe_image(path: str) -> MediaProbe:
@@ -107,14 +150,19 @@ class MediaPreparationPolicy:
         try:
             size = os.stat(path).st_size
         except OSError:
-            return PreparedMedia(path, path, MediaKind.DOCUMENT,
-                                 PreparationDecision.DOCUMENT_FALLBACK)
+            return self._fallback(path, preview_path, reason="compression_failed_fallback")
 
         # Telegram can accept this exact file as a photo; no Pillow import or
         # decode is needed. This also keeps normal operation working without PIL.
         if size <= self.max_bytes:
+            payload = _decision_payload(
+                path, size=size, decision="photo_passthrough",
+                reason="already_within_limits", policy=self,
+            )
+            log_media_decision(payload)
             return PreparedMedia(path, path, MediaKind.PHOTO,
-                                 PreparationDecision.PASS_THROUGH)
+                                 PreparationDecision.PASS_THROUGH,
+                                 decision=payload)
 
         try:
             probe = probe_image(path)
@@ -122,28 +170,66 @@ class MediaPreparationPolicy:
         except Exception:
             return self._fallback(path, preview_path)
 
-        if (probe.frames > 1
-                or estimate.estimated_peak_bytes > self.decode_budget_bytes):
-            return self._fallback(path, preview_path)
+        if probe.frames > 1 or estimate.estimated_peak_bytes > self.decode_budget_bytes:
+            return self._fallback(
+                path, preview_path, probe=probe, estimate=estimate,
+                reason="decode_budget_exceeded",
+            )
 
         derivative = compress_photo(path, self.max_bytes)
         if derivative:
+            payload = _decision_payload(
+                path, size=size, decision="safe_compress",
+                reason="photo_size_exceeded_but_decode_within_budget",
+                probe=probe, estimate=estimate, policy=self,
+                delivery=derivative,
+                preview_available=bool(preview_path),
+            )
+            log_media_decision(payload)
             return PreparedMedia(path, derivative, MediaKind.PHOTO,
-                                 PreparationDecision.SAFE_COMPRESS, True)
-        return self._fallback(path, preview_path)
+                                 PreparationDecision.SAFE_COMPRESS, True,
+                                 decision=payload)
+        return self._fallback(
+            path, preview_path, probe=probe, estimate=estimate,
+            reason="compression_failed_fallback",
+        )
 
-    def _fallback(self, path: str, preview_path: Optional[str]) -> PreparedMedia:
+    def _fallback(self, path: str, preview_path: Optional[str], *,
+                  reason: str = "decode_budget_exceeded",
+                  probe: Optional[MediaProbe] = None,
+                  estimate: Optional[MediaResourceEstimate] = None
+                  ) -> PreparedMedia:
+        try:
+            size = os.stat(path).st_size
+        except OSError:
+            size = 0
         if preview_path:
             try:
                 if os.stat(preview_path).st_size <= self.max_bytes:
+                    payload = _decision_payload(
+                        path, size=size, decision="use_preview",
+                        reason="preview_preferred"
+                        if reason == "decode_budget_exceeded"
+                        else "compression_failed_fallback",
+                        probe=probe, estimate=estimate, policy=self,
+                        delivery=preview_path, preview_available=True,
+                    )
+                    log_media_decision(payload)
                     return PreparedMedia(
                         path, preview_path, MediaKind.PHOTO,
-                        PreparationDecision.USE_PREVIEW,
+                        PreparationDecision.USE_PREVIEW, decision=payload,
                     )
             except OSError:
                 pass
+        payload = _decision_payload(
+            path, size=size, decision="document_fallback", reason=reason,
+            probe=probe, estimate=estimate, policy=self,
+            preview_available=bool(preview_path),
+        )
+        log_media_decision(payload)
         return PreparedMedia(path, path, MediaKind.DOCUMENT,
-                             PreparationDecision.DOCUMENT_FALLBACK)
+                             PreparationDecision.DOCUMENT_FALLBACK,
+                             decision=payload)
 
 
 def compress_photo(path: str, max_bytes: int) -> Optional[str]:
@@ -211,10 +297,15 @@ def cleanup_prepared_dicts(items: list) -> None:
 
 def reclassify_oversized_dicts(items: list, *,
                                 max_bytes: int = PHOTO_MAX_BYTES,
-                                use_preview: bool = False) -> list:
-    """Legacy dict facade over the canonical preparation policy."""
+                                use_preview: bool = False) -> tuple:
+    """Legacy dict facade over the canonical preparation policy.
+
+    Returns (items, decisions); decisions are the structured media-decision
+    payloads (one per classified photo) for the durable media.prepared audit.
+    """
     policy = MediaPreparationPolicy(max_bytes=max_bytes)
     out: list = []
+    decisions: list = []
     for item in items:
         if item.get("kind") == "photo" and item.get("path"):
             prepared = policy.prepare(
@@ -232,8 +323,13 @@ def reclassify_oversized_dicts(items: list, *,
                 item["filename"] = f"{base}.jpg"
             elif prepared.reason is PreparationDecision.USE_PREVIEW:
                 item["filename"] = os.path.basename(prepared.delivery_source)
+            if prepared.decision is not None:
+                decision = dict(prepared.decision)
+                if item.get("filename"):
+                    decision["filename"] = item["filename"]
+                decisions.append(decision)
         out.append(item)
-    return out
+    return out, decisions
 
 
 def reclassify_oversized(items: List[MediaItem], *,
@@ -262,10 +358,16 @@ def reclassify_oversized(items: List[MediaItem], *,
                     ),
                     item.spoiler if prepared.kind is MediaKind.PHOTO else False,
                 )
-                logger.info(
-                    "图片准备决策=%s source=%s delivery=%s",
-                    prepared.reason.value, prepared.original_source,
-                    prepared.delivery_source,
-                )
+                if prepared.decision is not None:
+                    payload = dict(prepared.decision)
+                    if filename:
+                        payload["filename"] = filename
+                    log_media_decision(payload)
+                else:
+                    logger.info(
+                        "图片准备决策=%s source=%s delivery=%s",
+                        prepared.reason.value, prepared.original_source,
+                        prepared.delivery_source,
+                    )
         out.append(item)
     return out

--- a/telepost/telegram/review_stager.py
+++ b/telepost/telegram/review_stager.py
@@ -90,9 +90,9 @@ class TelegramReviewStager:
     # ---- StagingPort ---------------------------------------------------
     async def stage_local(self, files, *, caption: str, spoiler: bool,
                           message_ids: Optional[List[int]] = None
-                          ) -> Tuple[list, list, List[int]]:
+                          ) -> Tuple[list, list, List[int], list]:
         ids: List[int] = message_ids if message_ids is not None else []
-        prepared = reclassify_oversized(
+        prepared, decisions = reclassify_oversized(
             list(files), max_bytes=self._photo_max_bytes, use_preview=True
         )
         staged_items = []
@@ -115,7 +115,7 @@ class TelegramReviewStager:
             media, documents = await self._stage(
                 staged_items, caption, spoiler, ids, local=True
             )
-            return media, documents, ids
+            return media, documents, ids, decisions
         finally:
             cleanup_prepared_dicts(prepared)
 

--- a/tests/test_media_decision_audit.py
+++ b/tests/test_media_decision_audit.py
@@ -1,0 +1,103 @@
+"""Structured media decision payloads (observability requirement #3)."""
+
+import builtins
+import logging
+
+import pytest
+
+from telepost.telegram.delivery import preparation as p
+
+
+def _sparse(path, size):
+    with open(path, "wb") as handle:
+        handle.truncate(size)
+
+
+_REQUIRED_FIELDS = {
+    "filename", "mime", "file_bytes", "width", "height", "mode",
+    "estimated_decode_bytes", "decode_budget_bytes",
+    "telegram_photo_limit", "preview_available", "decision", "reason",
+    "original_bytes",
+}
+
+
+@pytest.mark.unit
+def test_passthrough_payload_fields(tmp_path, caplog):
+    source = tmp_path / "normal.jpeg"
+    source.write_bytes(b"small")
+    with caplog.at_level(logging.INFO):
+        result = p.MediaPreparationPolicy().prepare(str(source))
+    assert result.decision["decision"] == "photo_passthrough"
+    assert result.decision["reason"] == "already_within_limits"
+    assert _REQUIRED_FIELDS <= set(result.decision)
+    assert result.decision["file_bytes"] == len(b"small")
+    assert result.decision["original_bytes"] == len(b"small")
+    assert any("media decision" in line for line in caplog.messages)
+
+
+@pytest.mark.unit
+def test_safe_compress_payload_within_decode_budget(tmp_path):
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    source = tmp_path / "big.jpg"
+    Image.new("RGB", (3000, 3000), (120, 30, 40)).save(source, quality=95)
+    with open(source, "ab") as handle:
+        handle.truncate(p.PHOTO_MAX_BYTES + 1)
+
+    result = p.MediaPreparationPolicy().prepare(str(source))
+    assert result.reason is p.PreparationDecision.SAFE_COMPRESS
+    payload = result.decision
+    assert payload["decision"] == "safe_compress"
+    assert payload["reason"] == "photo_size_exceeded_but_decode_within_budget"
+    assert payload["estimated_decode_bytes"] == 3000 * 3000 * 3
+    assert payload["prepared_bytes"] <= payload["telegram_photo_limit"]
+    assert payload["mode"] == "RGB"
+    p.cleanup_prepared_dicts([{"temporary": True, "path": result.delivery_source}])
+
+
+@pytest.mark.unit
+def test_huge_rgba_document_fallback_payload_no_decode(tmp_path, monkeypatch):
+    # Exactly the 7000x5400 RGBA memory-safety case: payload is produced while
+    # PIL load/convert/resize/thumbnail must never run.
+    source = tmp_path / "huge.png"
+    _sparse(source, p.PHOTO_MAX_BYTES + 1)
+
+    class Header:
+        size = (7000, 5400)
+        mode = "RGBA"
+        format = "PNG"
+        n_frames = 1
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+
+    from PIL import Image
+    for name in ("load", "convert", "resize", "thumbnail"):
+        monkeypatch.setattr(
+            Image.Image, name,
+            lambda *_a, _name=name, **_kw: (_ for _ in ()).throw(
+                AssertionError(f"Image.{_name} must not be called")
+            ),
+        )
+    monkeypatch.setattr(Image, "open", lambda *_a, **_kw: Header())
+
+    result = p.MediaPreparationPolicy().prepare(str(source))
+    assert result.reason is p.PreparationDecision.DOCUMENT_FALLBACK
+    payload = result.decision
+    assert payload["decision"] == "document_fallback"
+    assert payload["reason"] == "decode_budget_exceeded"
+    assert payload["mode"] == "RGBA"
+    assert payload["width"] == 7000 and payload["height"] == 5400
+    assert payload["estimated_decode_bytes"] == 7000 * 5400 * 4
+    assert payload["estimated_decode_bytes"] > payload["decode_budget_bytes"]
+
+
+@pytest.mark.unit
+def test_reclassify_dict_facade_returns_decisions(tmp_path):
+    source = tmp_path / "n.jpg"
+    source.write_bytes(b"x")
+    items, decisions = p.reclassify_oversized_dicts(
+        [{"kind": "photo", "path": str(source), "filename": "n.jpg"}]
+    )
+    assert items[0]["kind"] == "photo"
+    assert [d["decision"] for d in decisions] == ["photo_passthrough"]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,135 @@
+"""Observability layer: redaction, error classification, durable audit."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from database import db_manager
+from telepost.observability import audit as audit_mod
+from telepost.observability.errors import classify
+from telepost.observability.redact import (
+    redact_headers,
+    redact_text,
+    sanitize_detail,
+)
+
+
+# ---- redaction -------------------------------------------------------------
+
+@pytest.mark.unit
+def test_redact_text_masks_bot_token_and_bearer():
+    shaped = "123456789:AAEhBOweykLoeXAMPLE-TOKEN_abcdef1234567"
+    bearer = "tp_" + "x" * 40
+    text = (
+        f"calling https://api.telegram.org/bot{shaped}/sendMessage "
+        f"Authorization: Bearer {bearer} "
+        f"see ?token=secretvalue&q=ok password=hunter2"
+    )
+    out = redact_text(text)
+    assert shaped not in out
+    assert bearer not in out
+    assert "secretvalue" not in out
+    assert "hunter2" not in out
+    assert "q=ok" in out  # non-secret params survive
+
+
+@pytest.mark.unit
+def test_redact_headers_and_sanitize_detail():
+    token = "123456789:AAEhBOweykLoeXAMPLE-TOKEN_abcdef1234567"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Cookie": "session=abc",
+        "X-Telegram-Bot-Api-Secret-Token": "webhooksecret",
+        "X-Custom-Token": token,
+        "Content-Type": "application/json",
+    }
+    masked = redact_headers(headers)
+    assert all(v == "***" for k, v in masked.items() if k != "Content-Type")
+
+    clean = sanitize_detail({
+        "url": f"https://x/bot{token}/y",
+        "nested": [{"api_token": token}, {"ok": True}],
+        "headers": headers,
+        "plain": "kept",
+    })
+    rendered = str(clean)
+    assert token not in rendered
+    assert clean["plain"] == "kept"
+    assert clean["nested"][0]["api_token"] == "***"
+    assert clean["headers"]["Content-Type"] == "application/json"
+
+
+# ---- classification --------------------------------------------------------
+
+@pytest.mark.unit
+def test_classify_exception_and_status_mapping():
+    from telegram.error import BadRequest, RetryAfter, TimedOut
+
+    assert classify(TimedOut()) == "network_timeout"
+    assert classify(RetryAfter(1)) == "rate_limited"
+    assert classify(BadRequest("bad")) == "telegram_send_failed"
+    import aiosqlite
+    assert classify(aiosqlite.Error("x")) == "database_failed"
+    assert classify(None, 502) == "remote_5xx"
+    assert classify(None, 400) == "remote_4xx"
+    assert classify(None, 409) == "idempotency_conflict"
+    assert classify(None, 429) == "rate_limited"
+    assert classify(None) == "internal_error"
+    # True class survives an upstream 502 mapping.
+    assert classify(TimedOut(), 502) == "network_timeout"
+
+
+# ---- durable audit ---------------------------------------------------------
+
+@pytest.fixture
+async def audit_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(db_manager, "DB_PATH", str(tmp_path / "audit.db"))
+    await db_manager.init_db()
+    return db_manager
+
+
+@pytest.mark.asyncio
+async def test_record_and_list_events(audit_db):
+    await audit_mod.record_event(
+        "review.created", review_id=7, pixiv_id="123", work_type="illust",
+        target_id="daily", idempotency_key="api:1:k",
+        execution_id="exec-9", actor="telegram_user:1",
+        detail={"items": [{"decision": "photo_passthrough"}],
+                "token": "123456789:AAEhBOweykLoeXAMPLE-TOKEN_abcdef1234567"},
+    )
+    events = await audit_mod.list_events(review_id=7)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "review.created"
+    assert event["execution_id"] == "exec-9"
+    assert isinstance(event["detail"], dict)
+    assert event["detail"]["items"][0]["decision"] == "photo_passthrough"
+    # Secrets in detail are redacted before persistence.
+    assert event["detail"]["token"] == "***"
+
+    by_exec = await audit_mod.list_events(execution_id="exec-9")
+    assert [e["id"] for e in by_exec] == [event["id"]]
+
+    # limit + newest-first
+    for index in range(3):
+        await audit_mod.record_event("x", detail={"i": index})
+    assert len(await audit_mod.list_events(limit=2)) == 2
+
+
+@pytest.mark.asyncio
+async def test_record_event_swallows_db_failure(audit_db, caplog):
+    import logging
+    broken = AsyncMock(side_effect=RuntimeError("disk full"))
+    with patch.object(db_manager, "get_db", broken):
+        with caplog.at_level(logging.WARNING):
+            # Must never raise.
+            await audit_mod.record_event("review.created", review_id=1)
+    assert any("not persisted" in record.message for record in caplog.records)
+
+
+def test_execution_id_from_source_ref():
+    assert audit_mod.execution_id_from_ref(
+        '{"executionId": "abc-1"}'
+    ) == "abc-1"
+    assert audit_mod.execution_id_from_ref("bare-ref") == "bare-ref"
+    assert audit_mod.execution_id_from_ref("") is None
+    assert audit_mod.execution_id_from_ref('{"other": 1}') is None

--- a/tests/test_observability_lifecycle.py
+++ b/tests/test_observability_lifecycle.py
@@ -1,0 +1,369 @@
+"""Lifecycle audit events: submission duplicates, approve/publish, reconciler,
+retention, CLI inspect, and the router /version + /health fields."""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from database import db_manager
+from handlers import review
+from telepost.observability import audit as audit_mod
+
+
+@pytest.fixture
+async def review_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "reviews.db")
+    monkeypatch.setattr(db_manager, "DB_PATH", db_path)
+    monkeypatch.setattr(review, "REVIEW_CHAT_ID", -100123)
+    monkeypatch.setattr(review, "ADMIN_IDS", [123456789])
+    await db_manager.init_db()
+    return db_path
+
+
+def _photo_message(message_id=10, file_id="STAGED_PHOTO"):
+    message = MagicMock()
+    message.message_id = message_id
+    message.photo = [MagicMock(file_id=file_id)]
+    message.video = None
+    message.animation = None
+    message.audio = None
+    message.document = None
+    return message
+
+
+def _callback_update(data, user_id=123456789):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.callback_query.data = data
+    update.callback_query.answer = AsyncMock()
+    update.callback_query.edit_message_text = AsyncMock()
+    return update
+
+
+def _events(review_id):
+    return audit_mod.list_events(review_id=review_id, limit=100)
+
+
+@pytest.mark.asyncio
+async def test_submission_duplicate_emitted_on_idempotent_replay(review_db):
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+
+    repo = ReviewRepository()
+    rid = await repo.insert(NewReview(
+        idempotency_key="api:7:dup", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False,
+        media=[{"type": "photo", "file_id": "P"}], documents=[],
+        review_chat_id="-100123", review_message_ids=[10],
+    ))
+    await repo.update_staged(rid, media=[{"type": "photo", "file_id": "P"}],
+                             documents=[], preview_message_ids=[10])
+    await repo.finalize_control(rid, 11)
+
+    class Stager:
+        async def notify_reused(self, row):
+            self.row = row
+
+        async def cleanup_files(self, files):
+            pass
+
+    command = review.QueueCommand(
+        user_id=7, username="flow", tags="#x", title="", note="", link="",
+        anonymous=False, spoiler=False, source="api",
+        idempotency_key="api:7:dup", source_ref='{"executionId":"exec-dup"}',
+        review_chat_id="-100123",
+    )
+    result = await ReviewQueueService().enqueue(command, Stager(),
+                                                media=[{"x": 1}], documents=[])
+    assert result["reused"] is True
+
+    events = await _events(rid)
+    names = [e["event"] for e in events]
+    assert "submission.duplicate" in names
+    dup = next(e for e in events if e["event"] == "submission.duplicate")
+    assert audit_mod.detail_value(dup["detail"])["reused_id"] == rid
+    assert dup["execution_id"] == "exec-dup"
+
+
+@pytest.mark.asyncio
+async def test_double_approve_audit_events(review_db):
+    """review.approved exactly once; publish.completed once; the second click is
+    suppressed as publish.duplicate_suppressed."""
+    bot = AsyncMock()
+    bot.send_photo.return_value = _photo_message()
+    control = MagicMock()
+    control.message_id = 11
+    bot.send_message.return_value = control
+    queued = await review.queue_review_from_file_ids(
+        bot,
+        [{"type": "photo", "file_id": "ORIGINAL"}],
+        [],
+        tags="#pixiv", user_id=7, username="flow",
+        idempotency_key="pixiv:audit",
+    )
+    rid = queued["review_id"]
+
+    update = _callback_update(f"review_approve:{rid}")
+    context = MagicMock()
+    context.bot = bot
+    publish_result = {
+        "status": "published", "message_id": 99,
+        "link": "https://t.me/c/1/99",
+        "media_count": 1, "document_count": 0,
+    }
+    with patch("handlers.review.publish_from_file_ids",
+               AsyncMock(return_value=publish_result)):
+        await review.approve_review(update, context)
+        await review.approve_review(update, context)
+
+    # Let fire-and-forget audit tasks drain.
+    await asyncio.sleep(0)
+
+    events = await _events(rid)
+    names = [e["event"] for e in events]
+    assert names.count("review.approved") == 1
+    assert names.count("publish.completed") == 1
+    assert names.count("publish.duplicate_suppressed") == 1
+    # Queue lifecycle present as well.
+    for expected in ("review.created", "review.preview_staged",
+                     "review.control_created", "review.pending"):
+        assert expected in names
+
+
+@pytest.mark.asyncio
+async def test_approve_failure_records_typed_error_class(review_db):
+    from telegram.error import TimedOut
+
+    bot = AsyncMock()
+    bot.send_photo.return_value = _photo_message()
+    bot.send_message.return_value = MagicMock(message_id=11)
+    queued = await review.queue_review_from_file_ids(
+        bot, [{"type": "photo", "file_id": "X"}], [],
+        tags="#x", user_id=7, username="u", idempotency_key="k-fail",
+    )
+    rid = queued["review_id"]
+    with patch.object(
+        review.review_service, "_publish",
+        AsyncMock(side_effect=TimedOut("lost")),
+    ):
+        with pytest.raises(Exception):
+            await review.review_service.approve(bot, rid, actor=123456789)
+    await asyncio.sleep(0)
+    events = await _events(rid)
+    failed = [e for e in events if e["event"] == "review.failed"]
+    assert failed and failed[0]["error_class"] == "network_timeout"
+
+
+@pytest.mark.asyncio
+async def test_reconciler_emits_review_recreated_event(review_db):
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+
+    repo = ReviewRepository()
+    rid = await repo.insert(NewReview(
+        idempotency_key="api:7:rec", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False,
+        media=[{"type": "photo", "file_id": "P"}], documents=[],
+        review_chat_id="-100123", review_message_ids=[10],
+        status="failed",
+    ))
+
+    class Stager:
+        async def send_control_message_id(self, **kwargs):
+            return 22
+
+        async def delete_preview_messages(self, ids):
+            pass
+
+        async def cleanup_files(self, files):
+            pass
+
+    repaired = await ReviewQueueService().reconcile_incomplete(
+        Stager(), stale_seconds=0
+    )
+    assert repaired == 1
+    events = await _events(rid)
+    rec = [e for e in events if e["event"] == "review.reconciled"]
+    assert len(rec) == 1
+    assert audit_mod.detail_value(rec[0]["detail"])["action"] \
+        == "control_message_recreated"
+    assert rec[0]["actor"] == "system_reconciler"
+
+
+@pytest.mark.asyncio
+async def test_reconciler_orphan_preview_and_manual_intervention(review_db):
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+
+    repo = ReviewRepository()
+
+    # Orphan preview: no media/documents but preview ids exist.
+    orphan = await repo.insert(NewReview(
+        idempotency_key="api:7:orphan", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False, media=[], documents=[],
+        review_chat_id="-100123", review_message_ids=[55], status="preparing",
+    ))
+
+    # Control recreation itself fails -> manual intervention.
+    manual = await repo.insert(NewReview(
+        idempotency_key="api:7:manual", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False,
+        media=[{"type": "photo", "file_id": "P"}], documents=[],
+        review_chat_id="-100123", review_message_ids=[10], status="failed",
+    ))
+
+    class Stager:
+        async def send_control_message_id(self, **kwargs):
+            if kwargs["review_id"] == manual:
+                raise RuntimeError("telegram down")
+            return 22
+
+        async def delete_preview_messages(self, ids):
+            pass
+
+        async def cleanup_files(self, files):
+            pass
+
+    await ReviewQueueService().reconcile_incomplete(Stager(), stale_seconds=0)
+
+    orphan_events = await _events(orphan)
+    actions = [audit_mod.detail_value(e["detail"])["action"]
+               for e in orphan_events if e["event"] == "review.reconciled"]
+    assert "orphan_preview_removed" in actions
+
+    manual_events = await _events(manual)
+    rec = [e for e in manual_events if e["event"] == "review.reconciled"]
+    assert rec[0]["error_class"] == "reconciliation_failed"
+    assert audit_mod.detail_value(rec[0]["detail"])["action"] \
+        == "manual_intervention_required"
+
+
+@pytest.mark.asyncio
+async def test_audit_retention_keeps_open_review_events(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "ret.db")
+    monkeypatch.setattr(db_manager, "DB_PATH", db_path)
+    monkeypatch.setenv("AUDIT_RETENTION_DAYS", "30")
+    await db_manager.init_db()
+
+    now = __import__("time").time()
+    old = now - 40 * 86400
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+    repo = ReviewRepository()
+    open_id = await repo.insert(NewReview(
+        idempotency_key="api:1:open", source="api", user_id=1,
+        username="u", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False, media=[], documents=[],
+        review_chat_id="c", review_message_ids=[], status="pending",
+    ))
+    closed_id = await repo.insert(NewReview(
+        idempotency_key="api:1:closed", source="api", user_id=1,
+        username="u", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False, media=[], documents=[],
+        review_chat_id="c", review_message_ids=[], status="published",
+    ))
+    async with db_manager.get_db() as conn:
+        await conn.execute(
+            "INSERT INTO audit_events (ts,event,review_id) VALUES (?,?,?)",
+            (old, "x", open_id),
+        )
+        await conn.execute(
+            "INSERT INTO audit_events (ts,event,review_id) VALUES (?,?,?)",
+            (old, "x", closed_id),
+        )
+        await conn.execute(
+            "INSERT INTO audit_events (ts,event,review_id) VALUES (?,?,?)",
+            (old, "x", None),
+        )
+
+    await db_manager.cleanup_old_data()
+
+    async with db_manager.get_db() as conn:
+        remaining = [
+            row[0] for row in await (await conn.execute(
+                "SELECT review_id FROM audit_events"
+            )).fetchall()
+        ]
+    assert remaining == [open_id]
+
+
+def test_cli_reviews_inspect_on_seeded_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "submissions.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    # Re-import settings/DB_PATH for the CLI resolution helper.
+    import importlib
+    import config.settings as settings_mod
+    importlib.reload(settings_mod)
+    monkeypatch.setattr(db_manager, "DB_PATH", str(db_path))
+    import asyncio as _aio
+
+    async def seed():
+        await db_manager.init_db()
+        async with db_manager.get_db() as conn:
+            cur = await conn.execute(
+                "INSERT INTO pending_reviews (idempotency_key, source, status, "
+                "user_id, review_chat_id, media_json, documents_json, "
+                "review_message_ids, created_at, updated_at) "
+                "VALUES ('api:1:k','api','pending',1,'c','[]','[]','[]',?,?)",
+                (1.0, 1.0),
+            )
+            rid = cur.lastrowid
+            await conn.execute(
+                "INSERT INTO audit_events (ts,event,review_id,actor) "
+                "VALUES (?,?,?,?)", (2.0, "review.created", rid, "api"),
+            )
+            await conn.execute(
+                "INSERT INTO delivery_ledger (idempotency_key, target_id, "
+                "pixiv_id, work_type, status, message_id, related_message_ids, "
+                "user_id, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                (f"review:{rid}:api:1:k", "", "", "", "published", 5, "[]", 1, 2.0),
+            )
+            return rid
+
+    rid = _aio.new_event_loop().run_until_complete(seed())
+
+    from telepost.observability import cli
+    result = subprocess.run(
+        [sys.executable, "-m", "telepost.observability.cli",
+         "reviews", "inspect", str(rid)],
+        cwd=__import__("telepost").__path__[0].rsplit("/telepost", 1)[0],
+        capture_output=True, text=True,
+        env={**os.environ, "DB_PATH": str(db_path), "TOKEN": "x",
+             "CHANNEL_ID": "@c", "OWNER_ID": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "review.created" in result.stdout
+    assert f"review:{rid}:api:1:k" in result.stdout
+    assert "pending_reviews" in result.stdout or "idempotency_key" in result.stdout
+
+
+def test_router_version_and_health_fields():
+    import run as run_mod
+    from aiohttp.test_utils import TestClient, TestServer
+    from aiohttp import web
+    import aiohttp
+
+    async def go():
+        app = run_mod.build_router_app([])
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        try:
+            version = await (await client.get("/version")).json()
+            assert version["service"] == "telepost"
+            assert version["version"]
+            assert "commit" in version
+            health = await (await client.get("/health")).json()
+            assert health["version"] == version["version"]
+            assert health["commit"] == version["commit"]
+        finally:
+            await client.close()
+
+    asyncio.new_event_loop().run_until_complete(go())

--- a/tests/test_publish_idempotency.py
+++ b/tests/test_publish_idempotency.py
@@ -14,6 +14,12 @@ from database.db_manager import init_db
 from handlers import publish
 
 
+def audit_detail(event):
+    import json
+    detail = event.get("detail") or {}
+    return detail if isinstance(detail, dict) else json.loads(detail)
+
+
 def _photo_message(message_id: int):
     return SimpleNamespace(
         message_id=message_id,
@@ -68,3 +74,22 @@ async def test_direct_publish_idempotent_replay_then_historical_duplicate(monkey
     assert historical["reused"] is True
     assert historical["reuse_reason"] == "duplicate_existing"
     assert deliver.await_count == 1
+
+    # Direct-publish audit through the canonical PublicationService.
+    import asyncio
+    from telepost.observability import audit
+    await asyncio.sleep(0)
+    events = await audit.list_events(limit=100)
+    names = [e["event"] for e in events]
+    assert names.count("publish.started") == 1
+    assert names.count("publish.completed") == 1
+    assert names.count("publish.duplicate_suppressed") == 2
+    suppressed = [
+        e for e in events if e["event"] == "publish.duplicate_suppressed"
+    ]
+    assert {audit_detail(e)["reuse_reason"] for e in suppressed} == {
+        "idempotent_replay", "duplicate_existing"
+    }
+    completed = next(e for e in events if e["event"] == "publish.completed")
+    assert completed["pixiv_id"] == "55"
+    assert completed["idempotency_key"].endswith(":slot-a:t1")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -963,6 +963,17 @@ async def test_owner_can_approve_once(review_db):
         await review.approve_review(update, context)
 
     publish.assert_awaited_once()
+    await asyncio.sleep(0)
+    async with db_manager.get_db() as conn:
+        audit_rows = [
+            row[0] for row in await (await conn.execute(
+                "SELECT event FROM audit_events WHERE review_id=?",
+                (queued["review_id"],),
+            )).fetchall()
+        ]
+    assert audit_rows.count("review.approved") == 1
+    assert audit_rows.count("publish.completed") == 1
+    assert audit_rows.count("publish.duplicate_suppressed") == 1
     async with db_manager.get_db() as conn:
         cursor = await conn.execute(
             "SELECT status, published_message_id FROM pending_reviews WHERE id=?",

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -168,6 +168,23 @@ class TestRouterRelay:
             await runner.cleanup()
 
 
+def test_outbox_metrics_ignores_migrated_archive(tmp_path):
+    import json
+
+    outbox = tmp_path / "delivery-outbox"
+    (outbox / "migrated").mkdir(parents=True)
+    # Active failed manifest: counted.
+    (outbox / "active.json").write_text(json.dumps({"attempts": 3, "lastError": "x"}))
+    # Archived manifest already replayed to the SQLite outbox: ignored.
+    (outbox / "migrated" / "old.json").write_text(
+        json.dumps({"attempts": 9, "lastError": "already migrated"})
+    )
+    metrics = run_mod._outbox_metrics(str(outbox))
+    assert metrics["failed_files"] == 1
+    assert metrics["total_attempts"] == 3
+    assert metrics["files"] == 1
+
+
 class TestReadinessProbes:
     """/live always answers; /ready aggregates bot-child readiness (503 while
     any child is still warming, 200 once all are initialize()+start() done)."""

--- a/utils/api_server.py
+++ b/utils/api_server.py
@@ -59,6 +59,57 @@ def _error(status: int, code: str, message: str) -> web.Response:
     )
 
 
+async def _audit_submission(event: str, *, user_id, idempotency_key="",
+                            target_id="", work_type="", pixiv_id="",
+                            source_ref="", review_id=None, detail=None) -> None:
+    from telepost.observability import audit as audit_mod
+    await audit_mod.record_event(
+        event,
+        actor=f"telegram_user:{user_id}" if user_id else "api",
+        idempotency_key=idempotency_key or None,
+        target_id=target_id or None,
+        work_type=work_type or None,
+        pixiv_id=pixiv_id or None,
+        review_id=review_id,
+        execution_id=audit_mod.execution_id_from_ref(source_ref),
+        detail=detail,
+    )
+
+
+def _result_reused_id(result: dict):
+    return result.get("review_id") or result.get("message_id")
+
+
+def _audit_key(raw_key: str, result: dict, *, user_id: int) -> str:
+    """Mirror the review queue's key normalization so events link to the row."""
+    if not (raw_key and API_REVIEW_REQUIRED and result.get("review_id")):
+        return raw_key
+    from telepost.application.review_queue import normalize_idempotency_key
+    return normalize_idempotency_key(user_id, raw_key, "api")
+
+
+async def _audit_submission_outcome(result: dict, **kwargs) -> None:
+    if result.get("reused"):
+        reused_id = _result_reused_id(result)
+        await _audit_submission(
+            "submission.duplicate",
+            review_id=result.get("review_id") if result.get("status") in (
+                "pending_review", "pending"
+            ) else None,
+            detail={"reused_id": reused_id,
+                    "reuse_reason": result.get("reuse_reason", "")},
+            **kwargs,
+        )
+    else:
+        await _audit_submission(
+            "submission.accepted",
+            review_id=result.get("review_id")
+            if result.get("status") == "pending_review" else None,
+            detail={"message_id": result.get("message_id")},
+            **kwargs,
+        )
+
+
 def _ok(data, status: int = 200) -> web.Response:
     return web.json_response({"ok": True, "data": data}, status=status)
 
@@ -325,6 +376,7 @@ def add_api_routes(web_app, application) -> None:
             return _error(429, "rate_limited",
                           f"每小时最多 {SUBMIT_LIMIT_PER_HOUR} 次投稿，请稍后再试")
         _rate_cache.set(f"api:{user_id}", used + 1, ttl=3600)
+        await _audit_submission("submission.received", user_id=user_id)
 
         if (request.content_type or "").startswith("application/json"):
             # file_id 直投：素材已在 Telegram 服务器（file_id 归属本 bot），零媒体传输
@@ -402,6 +454,15 @@ def add_api_routes(web_app, application) -> None:
             logger.info(
                 "API file_id 投稿已处理: user=%s status=%s",
                 user_id, result.get("status"),
+            )
+            await _audit_submission_outcome(
+                result, user_id=user_id,
+                idempotency_key=_audit_key(
+                    provenance.get("idempotency_key", ""), result, user_id=user_id),
+                target_id=provenance.get("target_id", ""),
+                work_type=provenance.get("work_type", ""),
+                pixiv_id=provenance.get("pixiv_id", ""),
+                source_ref=_fields_source_ref(payload),
             )
             return _business_ack(result)
 
@@ -530,6 +591,15 @@ def add_api_routes(web_app, application) -> None:
         logger.info(
             "API 投稿已处理: user=%s status=%s",
             user_id, result.get("status"),
+        )
+        await _audit_submission_outcome(
+            result, user_id=user_id,
+            idempotency_key=_audit_key(
+                provenance.get("idempotency_key", ""), result, user_id=user_id),
+            target_id=provenance.get("target_id", ""),
+            work_type=provenance.get("work_type", ""),
+            pixiv_id=provenance.get("pixiv_id", ""),
+            source_ref=_fields_source_ref(fields),
         )
         return _business_ack(result)
 


### PR DESCRIPTION
Minimal observability/auditability on top of 2.16.1. SQLite append-only evidence + structured logs; no new deps, review DB row stays source of truth.

- durable `audit_events` (additive, boot-upgraded): submission/review/publish lifecycle, reconciler actions, actor; execution_id carried from source_ref for cross-service correlation
- media decision audit: one structured line per item + per-submission durable event with decision/reason/estimated decode/budget/bytes; no file content logged
- typed error classification (network_timeout/rate_limited/remote_5xx/media_decode_budget_exceeded/...) preserved even when API returns 502
- centralized secret redaction (bot token/Bearer/headers/detail)
- build identity: telepost/build_info.py single source + Dockerfile APP_VERSION/GIT_SHA args writing _release_version.py; router GET /version and version in /health; `run.py --version` uses it
- read-only CLI `python -m telepost.observability.cli reviews inspect <id> [--bot N]`
- audit retention 30d (AUDIT_RETENTION_DAYS) never pruning events on open reviews
- /health no longer counts migrated/ legacy outbox manifests as failed
- 563 passed / 1 skipped (adds media-decision, observability, lifecycle, idempotency audit tests)