### PR TITLE
chore(release): let release-please bump telepost/build_info.py version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "package-name": "TelePost",
       "include-v-in-tag": true,
       "include-component-in-tag": false,
-      "skip-github-release": true
+      "skip-github-release": true,
+      "extra-files": ["telepost/build_info.py"]
     }
   }
 }

--- a/telepost/build_info.py
+++ b/telepost/build_info.py
@@ -5,7 +5,10 @@ Docker image) may additionally drop a top-level ``_release_version.py`` next
 to the entry points; when present it overrides these committed defaults.
 """
 
-RELEASE_VERSION = "2.16.1"
+# Bumped automatically by release-please (extra-files in
+# release-please-config.json). Release bundles and images override it at build
+# time with the exact version/commit; this constant is the local-dev fallback.
+RELEASE_VERSION = "2.16.1"  # x-release-please-version
 RELEASE_COMMIT = "dev"
 BUILD_DATE = "dev"
 SERVICE = "telepost"


### PR DESCRIPTION
The committed build-info version was a hardcoded fallback that only a human remembered to update, so it silently drifted from the manifest on every release.

- annotate the constant with `# x-release-please-version`
- register `telepost/build_info.py` in `extra-files` for the root package

release-please now bumps it inside each release PR. Release bundles and images still override it at build time with the exact version/commit, so this only removes the drift. 563 tests pass.