### PR TITLE
fix(media): send oversized-dimension images as documents

### DIFF
--- a/telepost/telegram/delivery/preparation.py
+++ b/telepost/telegram/delivery/preparation.py
@@ -25,6 +25,9 @@ logger = logging.getLogger(__name__)
 
 #: Telegram photo (single and in-album) hard limit, with safety margin.
 PHOTO_MAX_BYTES = int((10.0 - 0.5) * 1024 * 1024)
+#: Telegram rejects a photo when width + height exceeds this sum, even when the
+#: file is well under the byte limit ("Photo_invalid_dimensions").
+PHOTO_MAX_DIMENSION_SUM = int(os.getenv("TELEPOST_PHOTO_MAX_DIMENSION_SUM", "10000"))
 IMAGE_DECODE_BUDGET_BYTES = max(
     1, int(os.getenv("TELEPOST_IMAGE_DECODE_BUDGET_MB", "64"))
 ) * 1024 * 1024
@@ -152,12 +155,26 @@ class MediaPreparationPolicy:
         except OSError:
             return self._fallback(path, preview_path, reason="compression_failed_fallback")
 
-        # Telegram can accept this exact file as a photo; no Pillow import or
-        # decode is needed. This also keeps normal operation working without PIL.
+        # Telegram can accept this exact file as a photo; no decode is needed.
+        # This also keeps normal operation working without PIL.
         if size <= self.max_bytes:
+            # Bytes alone are not sufficient: Telegram rejects photos whose
+            # width+height exceeds PHOTO_MAX_DIMENSION_SUM with
+            # "Photo_invalid_dimensions". Header-only probe (no pixel decode);
+            # an unreadable header keeps the pass-through behaviour.
+            try:
+                probe = probe_image(path)
+            except Exception:
+                probe = None
+            if probe is not None and \
+                    probe.width + probe.height > PHOTO_MAX_DIMENSION_SUM:
+                return self._fallback(
+                    path, preview_path, probe=probe,
+                    reason="photo_dimensions_too_large",
+                )
             payload = _decision_payload(
                 path, size=size, decision="photo_passthrough",
-                reason="already_within_limits", policy=self,
+                reason="already_within_limits", policy=self, probe=probe,
             )
             log_media_decision(payload)
             return PreparedMedia(path, path, MediaKind.PHOTO,

--- a/tests/test_media_preparation.py
+++ b/tests/test_media_preparation.py
@@ -54,6 +54,59 @@ def test_huge_rgba_never_enters_full_decode(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+def test_small_file_with_oversized_dimensions_falls_back_to_document(tmp_path, monkeypatch):
+    """Telegram rejects such photos with Photo_invalid_dimensions even though
+    the file is tiny; the original must go out as a document instead."""
+    source = tmp_path / "wide.png"
+    source.write_bytes(b"small")
+
+    class Header:
+        size = (7000, 5400)
+        mode = "RGBA"
+        format = "PNG"
+        n_frames = 1
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+
+    from PIL import Image
+    for name in ("load", "convert", "resize", "thumbnail"):
+        monkeypatch.setattr(
+            Image.Image, name,
+            lambda *_a, _name=name, **_kw: (_ for _ in ()).throw(
+                AssertionError(f"Image.{_name} must not be called")
+            ),
+        )
+    monkeypatch.setattr(Image, "open", lambda *_a, **_kw: Header())
+
+    result = preparation.MediaPreparationPolicy().prepare(str(source))
+    assert result.reason is preparation.PreparationDecision.DOCUMENT_FALLBACK
+    assert result.kind is MediaKind.DOCUMENT
+    assert result.delivery_source == str(source)
+    assert result.decision["reason"] == "photo_dimensions_too_large"
+
+
+@pytest.mark.unit
+def test_small_photo_within_dimension_limit_still_passes_through(tmp_path, monkeypatch):
+    source = tmp_path / "ok.png"
+    source.write_bytes(b"small")
+
+    class Header:
+        size = (1280, 720)
+        mode = "RGB"
+        format = "PNG"
+        n_frames = 1
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+
+    from PIL import Image
+    monkeypatch.setattr(Image, "open", lambda *_a, **_kw: Header())
+
+    result = preparation.MediaPreparationPolicy().prepare(str(source))
+    assert result.reason is preparation.PreparationDecision.PASS_THROUGH
+    assert result.kind is MediaKind.PHOTO
+
+
+@pytest.mark.unit
 def test_huge_rgba_uses_optional_preview_without_decoding(tmp_path, monkeypatch):
     source = tmp_path / "huge.png"
     preview = tmp_path / "preview.jpg"


### PR DESCRIPTION
Found by deployment acceptance on 2.17.0: submitting a **small** (0.19 MB) but **7000x5400** RGBA PNG failed with `Photo_invalid_dimensions`, because the pass-through branch only checked bytes. Telegram rejects a photo whose `width + height` exceeds 10000 regardless of file size, so any compact-but-huge illustration would fail during preview staging — in production this surfaced as:

```
review.failed  error_class=telegram_send_failed
detail={"stage":"preview_staging","error":"Photo_invalid_dimensions"}
```

**Fix:** before passing a file through as a photo, read its header (no pixel decode) and fall back to a document with `reason=photo_dimensions_too_large` when it cannot legally be a photo. An unreadable header keeps the previous behaviour, so operation without PIL is unchanged.

Tests: 2 new cases (oversized small file -> document with reason, in-limit photo -> pass-through), full suite 565 passed / 1 skipped.