### PR TITLE
chore(release-infra): bump ReleaseGraph to v1.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   release:
-    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1.4.1
     with:
       version: ${{ inputs.version || '' }}
       dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}


### PR DESCRIPTION
Pins the release infrastructure to the immutable version `v1.4.1`.

Opened by `releasegraph rollout` after the canary repository completed a release lifecycle on this version.
Reverting this pull request returns the repository to its previous pin.