### PR TITLE
chore(release-infra): bump ReleaseGraph to v1.4.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@33010e2ef085d7f27a6af48a1d67c9c31fb147cf # ReleaseGraph v1.4.5
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@36d1bbce3c00d13c5383706cbc66d9ba17f8f72c # ReleaseGraph v1.4.6
     with:
       version: ${{ inputs.version || '' }}
       dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}


### PR DESCRIPTION
Pins the release infrastructure to `v1.4.6` (commit `36d1bbce3c00d13c5383706cbc66d9ba17f8f72c`).

Opened by `releasegraph rollout` after the canary repository completed a release lifecycle on this version.
Reverting this pull request returns the repository to its previous pin.