### PR TITLE
fix(router): drop the PixivFlow long-request timeout workaround

### DIFF
--- a/run.py
+++ b/run.py
@@ -593,19 +593,22 @@ def build_router_app(indices: list):
         app.router.add_route("*", api_prefix + "/{tail:.*}", api_relay)
 
     # Combined-image integration bridge (NOT core TelePost behavior): when an
-    # external automation engine (PixivFlow) runs in the same container in
-    # external-clock mode, reverse-proxy /internal/* to its trigger port so the
-    # public hostname both wakes the machine and reaches the authenticated
-    # trigger API. TelePost stays agnostic of that engine's scheduler semantics
-    # — this is a dumb port relay, gated on the engine being present. In
-    # split/standalone deployments this block is absent entirely.
+    # external automation engine (PixivFlow) runs in the same container,
+    # reverse-proxy /internal/* to its trigger port so the public hostname both
+    # wakes the machine and reaches the authenticated trigger API. TelePost
+    # stays agnostic of that engine's scheduler semantics — this is a dumb port
+    # relay, gated on the engine being present. In split/standalone deployments
+    # this block is absent entirely.
     if pixivflow_enabled():
         trigger_port = int(os.environ.get("PIXIVFLOW_TRIGGER_PORT", "8090"))
         trigger_relay = make_relay(indices[0], None, port_override=trigger_port, ready_path="/health")
-        # Trigger runs are synchronous and can take several minutes; pin the
-        # longest router timeout for this path so the wake request stays open
-        # (it IS the activity lease) for the whole run instead of timing out.
-        os.environ.setdefault("ROUTER_TIMEOUT_SECONDS", "600")
+        # The trigger endpoint now durably records the slot and returns
+        # immediately (202 Accepted / 200 already_completed); the actual run
+        # happens in that engine's background scheduler. So this relay keeps the
+        # router's own default timeout (ROUTER_TIMEOUT_SECONDS, 300s — see
+        # client_session_context above) instead of a raised one. The old 600s
+        # setdefault existed only to hold a 10-40 min request open as an
+        # activity lease, and it produced measurable 502s at the 600s mark.
         app.router.add_route("*", "/internal", trigger_relay)
         app.router.add_route("*", "/internal/{tail:.*}", trigger_relay)
     return app


### PR DESCRIPTION
## Why

PixivFlow's HTTP trigger endpoint `POST /internal/schedules/<id>/run` used to **await the entire download run**, which takes 10-40 minutes. That open HTTP request doubled as the "activity lease" keeping the Fly machine awake, so TelePost raised `ROUTER_TIMEOUT_SECONDS` to 600 for the `/internal` relay so the request would not be cut off mid-run.

That workaround is now obsolete and harmful:

- PixivFlow's trigger endpoint is changing so it **durably records the slot and returns immediately** (`202 Accepted`, or `200 already_completed`), with execution happening in its background scheduler. There is no longer any long request to keep alive.
- The raised timeout caused real production failures: `HTTP=502 ELAPSED=600s` while the download was still running.

## What changed

- Delete `os.environ.setdefault("ROUTER_TIMEOUT_SECONDS", "600")` inside `if pixivflow_enabled():` in `run.py`.
- Rewrite the surrounding comment to explain the new reality: durable dispatch + immediate return, so the router's own default (`ROUTER_TIMEOUT_SECONDS`, **300s**, read in `client_session_context`) applies to the `/internal` relay.

## What did NOT change

- The `/internal` and `/internal/{tail:.*}` relay routes stay exactly as they are - only the timeout workaround goes away.
- `ROUTER_CHILD_READY_TIMEOUT` and the `ready_path="/health"` relay probe are untouched.
- `docs/CONFIGURATION.md` already documents the `ROUTER_TIMEOUT_SECONDS` default as `300`, so it needed no update. No test asserted `600`.

## Verification

```
$ grep -rn "ROUTER_TIMEOUT_SECONDS" . --exclude-dir=.venv --exclude-dir=.git --exclude-dir=htmlcov
./run.py:451:            total=float(os.environ.get("ROUTER_TIMEOUT_SECONDS", "300"))
./run.py:608:        # router's own default timeout (ROUTER_TIMEOUT_SECONDS, 300s - see
./docs/CONFIGURATION.md:39:| `ROUTER_TIMEOUT_SECONDS` | `300` | 多 Bot 父路由的上游总超时 |

$ .venv/bin/pytest tests/test_webhook_router.py tests/test_run_dispatcher.py tests/test_run_supervisor.py -q
28 passed, 4 warnings in 1.54s

$ python3 -m py_compile run.py
(exit 0)
```

Ad-hoc check that the env var is no longer mutated while both relay routes stay registered:

```
$ PIXIVFLOW_ENABLED=true PIXIVFLOW_TRIGGER_PORT=18090 .venv/bin/python -c "..."
ROUTER_TIMEOUT_SECONDS after build_router_app: None
routes: ['<DynamicResource  /internal/{tail}>', '<PlainResource  /internal>']
```

Not merged - opening for review only.
