### PR TITLE
docs: 侧边栏按信息架构规约收敛，拆分语言侧边栏

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 - 开始使用
-  - [文档中心](/)
+  - [概览](/)
   - [📥 下载](/download.md)
   - [安装与部署](/INSTALL.md)
   - [命令参考](/COMMANDS.md)
@@ -11,15 +11,10 @@
   - [运维手册](/OPERATIONS.md)
   - [故障排查](/TROUBLESHOOTING.md)
   - [性能与容量](/PERFORMANCE.md)
-- 开发者
+- 开发
   - [HTTP API](/API.md)
   - [MCP 投稿审核](/MCP_REVIEW.md)
   - [测试指南](/TESTING.md)
   - [运行时架构](/internals/architecture.md)
   - [投稿状态机](/internals/submission-flow.md)
   - [删帖与软删除](/internals/moderation.md)
-- English
-  - [Documentation](/en/)
-  - [📥 Download](/en/download.md)
-  - [Install & deploy](/en/INSTALL.md)
-  - [Commands](/en/COMMANDS.md)

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -1,0 +1,5 @@
+- Getting Started
+  - [Overview](/en/)
+  - [📥 Download](/en/download.md)
+  - [Install & Deploy](/en/INSTALL.md)
+  - [Commands](/en/COMMANDS.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,11 +50,13 @@
       name: '📮 TelePost',
       nameLink: '#/',
       repo: 'redtidev1918/TelePost',
-      loadSidebar: true,
+            loadSidebar: true,
+      // 语言是站点维度：docsify 原生按页面所在目录取 _sidebar.md——
+      // 根页面读 /_sidebar.md，/en/ 页面读 /en/_sidebar.md，无需 alias。
+      // 注意：不要配置 '/.*/_sidebar.md' 之类的通配 alias，它会把 /en/_sidebar.md
+      // 改写回根侧边栏，破坏分语言导航；页内标题也不注入 sidebar（无 subMaxLevel）。
+
       // 子目录页面（如 zh-CN/）也统一用根侧边栏；链接用根绝对路径（/FOO.md）
-      alias: { '/.*/_sidebar.md': '/_sidebar.md' },
-      subMaxLevel: 2,
-      maxLevel: 3,
       auto2top: true,
       search: {
         placeholder: '搜索文档…',


### PR DESCRIPTION
按 [docsite 导航与信息架构规约](https://github.com/redtidev1918/docsite/pull/3) 收敛（DAViewer 试点后第二批）：

- `docs/_sidebar.md` 改为**中文单语**、任务型分类：首页条目称「概览」（Overview）；下载仅保留一个入口；删除页内锚点项、底部 English 整组与单页面顶级分类
- 新增 `docs/en/_sidebar.md`（**英文单语**）：与中文结构语义对称、页面一一对应；无英文翻译的页面不造伪英文入口（标注式 fallback 见规约）
- `docs/index.html`：移除 `/.*/_sidebar.md` 通配 alias（会把 /en/ 页面静默改写回根侧边栏）与 `subMaxLevel`/`maxLevel`（页内标题注入 sidebar 渲染），改由 docsify 原生按页面目录解析侧边栏

不删任何首页/文档内容，不改 runtime code，不发 release。验收：`docsite.py navcheck` ✅（本仓已跑通）。