### PR TITLE
PROBE (negative): branch-contract RED fixture — DO NOT MERGE

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -61,3 +61,5 @@ primary_region = ""
 # 3. 设置密钥: flyctl secrets set TOKEN=xxx CHANNEL_ID=@xxx OWNER_ID=xxx WEBHOOK_URL=https://xxx.fly.dev
 #    （代码兼容 BOT_TOKEN / TELEGRAM_BOT_TOKEN 作为别名）
 # 4. 后续部署使用: flyctl deploy
+
+# Branch-contract probe (negative): comment-only change inside the declared cutover scope.


### PR DESCRIPTION
Negative gate probe for the production-operation branch contract. Intentionally derived from a stale production base (`origin/main~1`) while touching only declared cutover scope. It must be REJECTED with an ancestry diagnostic. Exercises the real GitHub reusable workflow; closed without merging. DO NOT MERGE.