### PR TITLE
fix(handlers): 菜单命中后中止后续 group，消除「关于」等按钮的双重回复

### DIFF
--- a/handlers/command_handlers.py
+++ b/handlers/command_handlers.py
@@ -4,7 +4,7 @@
 import logging
 from datetime import datetime
 from telegram import Update, ReplyKeyboardRemove
-from telegram.ext import ConversationHandler, CallbackContext
+from telegram.ext import ConversationHandler, CallbackContext, ApplicationHandlerStop
 
 from database.db_manager import get_db
 from utils.blacklist import (
@@ -127,7 +127,13 @@ async def help_command(update: Update, context: CallbackContext):
 
 
 async def handle_menu_shortcuts(update: Update, context: CallbackContext) -> None:
-    """处理底部菜单（ReplyKeyboard）文本，映射到实际命令。"""
+    """处理底部菜单（ReplyKeyboard）文本，映射到实际命令。
+
+    命中任意分支后必须 **抛出** ApplicationHandlerStop：PTB 会顺序执行每一个
+    group，只有抛异常才会中断链路，仅仅 return 不会。否则同一条菜单文本在正常
+    回复之后还会落到 group=1000 的 catch_all，用户会额外收到一条
+    「🤔 这条消息我没看懂」。
+    """
     # 排除频道消息
     if update.channel_post or update.edited_channel_post:
         return
@@ -142,52 +148,58 @@ async def handle_menu_shortcuts(update: Update, context: CallbackContext) -> Non
         return
     
     text = (update.message.text or "").strip()
+    handled = False
     try:
         # 如果处于搜索输入模式，优先交给搜索输入处理
         if context.user_data.get('search_mode'):
             from handlers.search_handlers import handle_search_input
             await handle_search_input(update, context)
-            return
+            handled = True
         # 开始投稿：已由 ConversationHandler 的 entry（Regex「开始投稿」）接管，
         # 这里不再直接调 submit——直接调只建 DB 会话、不建立状态机内存状态，
         # 用户随后发的媒体会掉出状态机而静默无响应。
         # 我的统计
-        if text.endswith("我的统计"):
+        elif text.endswith("我的统计"):
             from handlers.stats_handlers import get_user_stats
             await get_user_stats(update, context)
-            return
+            handled = True
         # 我的投稿
-        if text.endswith("我的投稿"):
+        elif text.endswith("我的投稿"):
             from handlers.search_handlers import get_my_posts
             await get_my_posts(update, context)
-            return
+            handled = True
         # 热门内容
-        if text.endswith("热门内容"):
+        elif text.endswith("热门内容"):
             from handlers.stats_handlers import get_hot_posts
             await get_hot_posts(update, context)
-            return
+            handled = True
         # 标签云
-        if text.endswith("标签云"):
+        elif text.endswith("标签云"):
             from handlers.search_handlers import get_tag_cloud
             await get_tag_cloud(update, context)
-            return
+            handled = True
         # 搜索
-        if text.endswith("搜索"):
+        elif text.endswith("搜索"):
             await update.message.reply_text(
                 "🔍 请输入搜索关键词，或点击下方选项：",
                 reply_markup=Keyboards.search_options()
             )
-            return
+            handled = True
         # 帮助
-        if text.endswith("帮助"):
+        elif text.endswith("帮助"):
             await help_command(update, context)
-            return
+            handled = True
         # 关于
-        if text.endswith("关于"):
+        elif text.endswith("关于"):
             await update.message.reply_text(MessageFormatter.about_message(), parse_mode="HTML")
-            return
+            handled = True
     except Exception as e:
+        # 处理失败时不中止链路，交由 catch_all 给出兜底指引
         logger.error(f"处理菜单快捷操作失败: {e}")
+        return
+
+    if handled:
+        raise ApplicationHandlerStop()
 
 
 async def settings(update: Update, context: CallbackContext):

--- a/main.py
+++ b/main.py
@@ -131,7 +131,8 @@ async def check_conversation_timeout(update: Update, context: CallbackContext) -
     if is_blacklisted(user_id):
         logger.warning(f"黑名单用户 {user_id} 尝试发送消息")
         await update.message.reply_text("❌ 您已被列入黑名单，无法使用此机器人。")
-        return ApplicationHandlerStop()
+        # 必须 raise：return 不会中断后续 group，用户会再收到一条兜底回复
+        raise ApplicationHandlerStop()
     
     # 检查投稿会话是否超时。
     # 说明：会话活跃时间以 submissions.timestamp 为准（投稿流程每一步都会刷新）。
@@ -171,9 +172,14 @@ async def check_conversation_timeout(update: Update, context: CallbackContext) -
             except Exception as e:
                 logger.error(f"发送超时通知失败: {e}")
 
-            return ApplicationHandlerStop()
+            # 必须 raise：return 不会中断后续 group，超时通知后会再跟一条兜底回复
+            raise ApplicationHandlerStop()
 
         logger.debug(f"用户 {user_id} 会话活跃 ({time_diff:.2f}秒 < {TIMEOUT_SECONDS}秒)")
+    except ApplicationHandlerStop:
+        # 原样抛回：ApplicationHandlerStop 是 Exception 子类，
+        # 若不在此处先拦截，会被下面的 except Exception 吃掉而失效
+        raise
     except Exception as e:
         logger.error(f"检查会话超时时发生错误: {e}")
         # 出错时不阻止消息处理继续，而是让正常流程继续
@@ -215,7 +221,8 @@ async def orphan_media_guard(update: Update, context: CallbackContext) -> None:
         )
     except Exception as e:
         logger.warning("发送会话外媒体提示失败: %s", e)
-    return ApplicationHandlerStop()
+    # 必须 raise：否则 group=1000 的 catch_all 会对同一条媒体再回一次「我没看懂」
+    raise ApplicationHandlerStop()
 
 # 添加全局更新记录器
 async def log_all_updates(update: Update, context: CallbackContext) -> None:

--- a/tests/test_menu_shortcut_single_reply.py
+++ b/tests/test_menu_shortcut_single_reply.py
@@ -1,0 +1,143 @@
+"""底部菜单文本必须只产生一条回复。
+
+回归背景（生产实测）：
+用户点击 ReplyKeyboard 的「ℹ️ 关于」，收到「关于」卡片后**又**收到一条
+「🤔 这条消息我没看懂」。
+
+原因是 PTB 的分组语义：``Application.process_update`` 会顺序执行**每一个**
+group，只有处理器**抛出** ``ApplicationHandlerStop`` 才会中断后续 group
+（``telegram/ext/_application.py`` 中 ``except ApplicationHandlerStop: break``），
+仅仅 ``return`` 不会。``handle_menu_shortcuts``(group=998) 当时只 return，
+于是 group=1000 的 ``catch_all`` 又兜底回复了一次。
+
+本文件用真实的 ``Application`` + 真实 group 编号复现该链路，并锁死两类不变量：
+1. 菜单按钮文本只回一条，且不是兜底文案；
+2. 真正的未知文本仍然能拿到兜底指引（不要为了修 bug 把兜底关掉）。
+"""
+import inspect
+from pathlib import Path
+
+import pytest
+from telegram import Chat, Message, MessageEntity, Update, User
+from telegram.ext import Application, MessageHandler, filters
+
+from handlers.command_handlers import catch_all, handle_menu_shortcuts
+
+PROJECT_ROOT = Path(__file__).parents[1]
+
+
+class _RecordingBot:
+    """记录所有出站消息的最小 Bot 替身。"""
+
+    def __init__(self):
+        self.outbox = []
+        self._mid = 1000
+        self.id = 777
+        self.username = "testbot"
+        self.name = "testbot"
+
+    async def initialize(self):
+        pass
+
+    async def shutdown(self):
+        pass
+
+    def _msg(self):
+        from unittest.mock import MagicMock
+
+        self._mid += 1
+        m = MagicMock()
+        m.message_id = self._mid
+        return m
+
+    async def send_message(self, chat_id, text, **kw):
+        self.outbox.append(text)
+        return self._msg()
+
+    async def send_photo(self, chat_id, **kw):
+        self.outbox.append("<photo>")
+        return self._msg()
+
+    async def edit_message_text(self, *a, **kw):
+        return self._msg()
+
+
+def _text_update(text, user_id=42):
+    user = User(id=user_id, is_bot=False, first_name="T", username="tester")
+    chat = Chat(id=user_id, type="private")
+    kw = dict(message_id=1, date=0, chat=chat, from_user=user, text=text)
+    if text.startswith("/"):
+        kw["entities"] = (
+            MessageEntity(type="bot_command", offset=0, length=len(text.split()[0])),
+        )
+    return Update(update_id=1, message=Message(**kw))
+
+
+def _build_app(bot):
+    """按 main.py 的生产分组注册：菜单 998，兜底 1000。"""
+    app = Application.builder().bot(bot).build()
+    app.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_menu_shortcuts), group=998
+    )
+    app.add_handler(MessageHandler(filters.ALL, catch_all), group=1000)
+    return app
+
+
+async def _process(app, bot, update):
+    update.set_bot(bot)
+    if update.message:
+        update.message.set_bot(bot)
+    await app.process_update(update)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label", ["ℹ️ 关于", "🔍 搜索"])
+async def test_menu_button_replies_exactly_once(monkeypatch, label):
+    """点击菜单按钮只回一条，且不是兜底文案。"""
+    monkeypatch.setattr(
+        "handlers.command_handlers.MessageFormatter.about_message",
+        staticmethod(lambda: "ℹ️ 关于投稿机器人"),
+    )
+    bot = _RecordingBot()
+    app = _build_app(bot)
+    await app.initialize()
+    try:
+        await _process(app, bot, _text_update(label))
+    finally:
+        await app.shutdown()
+
+    assert len(bot.outbox) == 1, f"「{label}」应只回一条，实际 {len(bot.outbox)} 条: {bot.outbox}"
+    assert "我没看懂" not in bot.outbox[0], f"「{label}」不应触发 catch_all 兜底: {bot.outbox}"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_text_still_gets_fallback(monkeypatch):
+    """未知文本仍然拿到兜底指引——修复不能把兜底整体关掉。"""
+    bot = _RecordingBot()
+    app = _build_app(bot)
+    await app.initialize()
+    try:
+        await _process(app, bot, _text_update("今天天气不错", user_id=99))
+    finally:
+        await app.shutdown()
+
+    assert len(bot.outbox) == 1, f"未知文本应回一条兜底，实际: {bot.outbox}"
+    assert "我没看懂" in bot.outbox[0]
+
+
+def test_no_handler_returns_application_handler_stop():
+    """ApplicationHandlerStop 只能 raise，不能 return。
+
+    return 一个异常实例不会中断 group（PTB 只看是否抛出），
+    历史上 main.py 三处都误写成 return，导致「黑名单/会话超时/会话外媒体」
+    的提示后面还会再跟一条兜底回复。
+    """
+    for rel in ("main.py", "handlers/command_handlers.py"):
+        source = (PROJECT_ROOT / rel).read_text(encoding="utf-8")
+        assert "return ApplicationHandlerStop" not in source, f"{rel} 中出现了无效的 return ApplicationHandlerStop"
+
+
+def test_menu_shortcuts_stops_chain_after_handling():
+    """handle_menu_shortcuts 命中后必须抛出 ApplicationHandlerStop。"""
+    source = inspect.getsource(handle_menu_shortcuts)
+    assert "raise ApplicationHandlerStop" in source


### PR DESCRIPTION
用户点击底部键盘「ℹ️ 关于」后，除「关于」卡片外还会收到一条「🤔 这条消息我没看懂」。

根因：PTB 会顺序执行每一个 group，只有抛出 ApplicationHandlerStop 才会中断链路（telegram/ext/_application.py: except ApplicationHandlerStop: break），仅仅 return 不会。handle_menu_shortcuts(group=998) 当年只 return，于是 group=1000 的 catch_all 又兜底回复了一次。

同一类失效还有三处：main.py 的「黑名单拦截」「会话超时通知」「会话外媒体提示」都写成 return ApplicationHandlerStop()，返回一个异常实例等于没写，这三条提示后面同样会再跟一条兜底回复。其中会话超时那处位于 try 内，需在 except Exception 之前显式 except ApplicationHandlerStop: raise，否则会被吞掉。

最小修复：上述 return 全部改为 raise；handle_menu_shortcuts 命中任意分支后抛出 ApplicationHandlerStop（处理异常时保持不中止，交由 catch_all 给出兜底指引）。附带效果：search_mode 下 handle_search_input 不再被 998/999 两个 group 各执行一次。

回归测试 tests/test_menu_shortcut_single_reply.py 用真实 Application 与真实 group 编号复现链路：菜单文本只回一条且非兜底文案、未知文本仍能拿到兜底、禁止 return ApplicationHandlerStop。修复前该测试失败，修复后通过；全量 571 passed / 1 skipped。
