### PR TITLE
fix(submission): keep slow submissions decidable and idempotent

### DIFF
--- a/telepost/application/review_queue.py
+++ b/telepost/application/review_queue.py
@@ -14,8 +14,10 @@ Idempotency contract
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
 import re
 import time
 import uuid
@@ -27,6 +29,19 @@ from ..observability.errors import classify as classify_error
 from ..storage.sqlite.reviews import NewReview, ReviewRepository
 
 logger = logging.getLogger(__name__)
+
+# The routing layer (run.py) answers 502 for any request slower than
+# ROUTER_TIMEOUT_SECONDS (300s default), which reports an IN-FLIGHT submission
+# as a transport failure. Staging must therefore finish its own Telegram work
+# well inside that budget, and must renew its review row often enough that the
+# periodic reconciliation sweep (60s staleness) can tell a live request apart
+# from a crashed one.
+STAGING_DEADLINE_SECONDS = float(
+    os.environ.get("REVIEW_STAGING_DEADLINE_SECONDS", "240")
+)
+PREPARATION_HEARTBEAT_SECONDS = float(
+    os.environ.get("REVIEW_HEARTBEAT_SECONDS", "20")
+)
 
 
 def _actor(user_id: Any = None) -> str:
@@ -109,9 +124,37 @@ class StagingPort(Protocol):
 
 class ReviewQueueService:
     def __init__(self, repo: Optional[ReviewRepository] = None,
-                 dedup_window_seconds: int = PUBLISHED_DEDUP_WINDOW_SECONDS):
+                 dedup_window_seconds: int = PUBLISHED_DEDUP_WINDOW_SECONDS,
+                 staging_deadline_seconds: float = STAGING_DEADLINE_SECONDS,
+                 heartbeat_seconds: float = PREPARATION_HEARTBEAT_SECONDS):
         self._repo = repo or ReviewRepository()
         self._dedup_window = dedup_window_seconds
+        self._staging_deadline_seconds = staging_deadline_seconds
+        self._heartbeat_seconds = heartbeat_seconds
+
+    # ---- in-flight liveness ---------------------------------------------
+    async def _heartbeat_preparing(self, review_id: int) -> None:
+        """Renew the review row while this request is genuinely working.
+
+        Without it a submission whose staging outlived the sweep's staleness
+        window was indistinguishable from a crash leftover, so the sweeper
+        deleted the previews this request had just uploaded and marked the
+        review failed (see ReviewRepository.touch_preparing).
+        """
+        try:
+            while True:
+                await asyncio.sleep(self._heartbeat_seconds)
+                if not await self._repo.touch_preparing(review_id):
+                    return  # left 'preparing': this request lost the row
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("审核准备心跳失败: review_id=%s", review_id, exc_info=True)
+
+    @staticmethod
+    async def _stop_heartbeat(task: "asyncio.Task") -> None:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
 
     # ---- result mapping --------------------------------------------------
     @staticmethod
@@ -189,6 +232,16 @@ class ReviewQueueService:
 
         await _record("review.created", command, review_id=review_id)
 
+        # A live staging request and a crashed one look identical in the ledger
+        # (status='preparing', control_message_id NULL), so the reconciliation
+        # sweep used to hijack submissions whose staging outlived its staleness
+        # window. Renew the row while we work on it, and bound the staging so
+        # this request answers before the router's timeout turns it into a
+        # synthetic 502 (which hides whether the submission was processed).
+        heartbeat = asyncio.create_task(self._heartbeat_preparing(review_id))
+        set_deadline = getattr(stager, "set_staging_deadline", None)
+        if callable(set_deadline):
+            set_deadline(time.monotonic() + self._staging_deadline_seconds)
         media_decisions: list = []
         try:
             # Pass the id list in-out: when staging fails mid-way, ids of
@@ -234,6 +287,10 @@ class ReviewQueueService:
             if is_local:
                 await stager.cleanup_files(files)
             raise
+        finally:
+            if callable(set_deadline):
+                set_deadline(None)
+            await self._stop_heartbeat(heartbeat)
 
         try:
             staged = await self._repo.update_staged(

--- a/telepost/storage/sqlite/reviews.py
+++ b/telepost/storage/sqlite/reviews.py
@@ -167,6 +167,31 @@ class ReviewRepository:
             )
             return list(await cur.fetchall())
 
+    async def touch_preparing(self, review_id: int) -> bool:
+        """Renew the liveness marker of an IN-FLIGHT preparation.
+
+        A request that is still staging its previews and a request that died
+        mid-staging are indistinguishable in this table: both leave
+        ``status='preparing'`` with ``control_message_id IS NULL``. That is
+        exactly the predicate ``list_incomplete`` uses to decide what the
+        reconciliation sweep may repair, so a submission whose staging outlives
+        the staleness window was treated as crash leftovers and destroyed by
+        the sweeper while its own handler was still running. A live handler
+        renews ``updated_at`` here, so ``updated_at <= cutoff`` really means
+        "nobody has signalled liveness for N seconds".
+
+        Scoped to ``status='preparing'`` so a heartbeat can never resurrect a
+        row another writer already moved on (staged/pending/failed/published),
+        and returns whether the row was still ours to renew.
+        """
+        async with db_manager.get_db() as conn:
+            cur = await conn.execute(
+                "UPDATE pending_reviews SET updated_at=? "
+                "WHERE id=? AND status='preparing'",
+                (time.time(), int(review_id)),
+            )
+            return cur.rowcount == 1
+
     async def delete(self, review_id: int) -> None:
         async with db_manager.get_db() as conn:
             await conn.execute("DELETE FROM pending_reviews WHERE id=?",

--- a/telepost/telegram/review_stager.py
+++ b/telepost/telegram/review_stager.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from collections.abc import Awaitable, Callable
 from typing import List, Optional, Tuple
 
@@ -85,7 +86,11 @@ class TelegramReviewStager:
         self._thread = thread
         self._sleep = sleep
         self._photo_max_bytes = photo_max_bytes
+        self._preview_timeout = preview_timeout
         self._timeouts = timeout_kwargs(preview_timeout)
+        # Monotonic deadline of the CURRENT staging call, or None when the
+        # caller does not require bounded staging (background repair / tests).
+        self._staging_deadline: Optional[float] = None
 
     # ---- StagingPort ---------------------------------------------------
     async def stage_local(self, files, *, caption: str, spoiler: bool,
@@ -174,7 +179,7 @@ class TelegramReviewStager:
         text = review_keyboard.reused_notice_text(row)
         kwargs = {
             "chat_id": self.chat_id, "text": text,
-            "disable_web_page_preview": True, **self._timeouts,
+            "disable_web_page_preview": True, **self._timeouts_now(),
         }
         message_ids = _review_message_ids(row)
         if str(row["review_chat_id"]) == str(self.chat_id) and message_ids:
@@ -211,14 +216,47 @@ class TelegramReviewStager:
                           or pixiv_id_from_link(command.link or "")),
             ),
             disable_web_page_preview=True,
-            **self._timeouts,
+            **self._timeouts_now(),
         ))
         return message.message_id
+
+    # ---- staging budget -------------------------------------------------
+    def set_staging_deadline(self, deadline: Optional[float]) -> None:
+        """Bound how long the CURRENT staging call may take (monotonic clock).
+
+        Submissions are staged inline inside the HTTP request, while the routing
+        layer answers 502 for anything slower than its own timeout
+        (``ROUTER_TIMEOUT_SECONDS``). Unbounded retries therefore handed callers
+        a synthetic 502 for a submission that was still running, which makes
+        "not processed" and "processed and failed" indistinguishable. Every
+        remaining Telegram call is capped to the remaining budget here, so the
+        request always answers by itself before the router gives up.
+        """
+        self._staging_deadline = deadline
+
+    def _budget_left(self) -> Optional[float]:
+        if self._staging_deadline is None:
+            return None
+        return self._staging_deadline - time.monotonic()
+
+    def _timeouts_now(self) -> dict:
+        left = self._budget_left()
+        if left is None or left >= self._preview_timeout:
+            return self._timeouts
+        return timeout_kwargs(max(left, 1.0))
+
+    def _require_budget(self) -> None:
+        left = self._budget_left()
+        if left is not None and left <= 0:
+            raise RuntimeError(
+                "审核预览暂存超时（submission staging timeout），本次投稿未完成"
+            )
 
     # ---- throttle ------------------------------------------------------
     async def _send_throttled(self, factory: Callable[[], Awaitable]):
         last_error = None
         for attempt in range(self._max_attempts):
+            self._require_budget()
             try:
                 return await factory()
             except RetryAfter as exc:
@@ -242,6 +280,11 @@ class TelegramReviewStager:
                 wait = 5.0
             if attempt + 1 >= self._max_attempts:
                 raise last_error
+            left = self._budget_left()
+            if left is not None:
+                # Never sleep past the staging deadline: the next attempt would
+                # be rejected anyway, and the request must answer in time.
+                wait = min(wait, max(left, 0.0))
             await self._sleep(wait)
         raise RuntimeError("审核预览重试次数已耗尽")
 
@@ -289,7 +332,7 @@ class TelegramReviewStager:
                         caption=caption if index == 0 else None,
                         spoiler=spoiler, filename=item["filename"],
                     ))
-                kwargs = dict(chat_id=self.chat_id, media=group, **self._timeouts)
+                kwargs = dict(chat_id=self.chat_id, media=group, **self._timeouts_now())
                 if reply_to is not None:
                     kwargs["reply_to_message_id"] = reply_to
                 return await self._bot.send_media_group(**kwargs)
@@ -302,7 +345,7 @@ class TelegramReviewStager:
         return await self._send_throttled(factory)
 
     async def _local_single(self, item, caption, spoiler, reply_to):
-        common = {"chat_id": self.chat_id, **self._timeouts}
+        common = {"chat_id": self.chat_id, **self._timeouts_now()}
         if reply_to is not None:
             common["reply_to_message_id"] = reply_to
         kind = item["kind"]
@@ -348,7 +391,7 @@ class TelegramReviewStager:
             )
             for index, item in enumerate(chunk)
         ]
-        kwargs = dict(chat_id=self.chat_id, media=group, **self._timeouts)
+        kwargs = dict(chat_id=self.chat_id, media=group, **self._timeouts_now())
         if reply_to is not None:
             kwargs["reply_to_message_id"] = reply_to
         return await self._send_throttled(
@@ -356,7 +399,7 @@ class TelegramReviewStager:
         )
 
     async def _file_id_single(self, item, caption, spoiler, reply_to):
-        common = {"chat_id": self.chat_id, **self._timeouts}
+        common = {"chat_id": self.chat_id, **self._timeouts_now()}
         if reply_to is not None:
             common["reply_to_message_id"] = reply_to
         kind = item["kind"]

--- a/tests/test_submission_timeout_idempotency.py
+++ b/tests/test_submission_timeout_idempotency.py
@@ -1,0 +1,325 @@
+"""Regression: a slow submission must stay decidable and non-duplicating.
+
+Production evidence (2026-09-12, bot2-daily@2026-09-12T1810, review #59):
+
+* the request staged two large illustration previews inline (18:48:38Z);
+* the periodic reconciliation sweep (``stale_seconds=60``) selected the LIVE
+  row — ``status='preparing'`` with ``control_message_id IS NULL`` — deleted
+  the previews this request had just uploaded and marked the review ``failed``
+  at 18:50:28Z;
+* the routing layer answered 502 at 18:53:39Z (``ROUTER_TIMEOUT_SECONDS``)
+  while the handler was still running, so the caller could not tell "not
+  processed" from "processed and failed";
+* the retry with the same idempotency key returned the reused ``failed`` row as
+  HTTP 200 / ``ok: true`` / ``business_status=idempotent_replay`` /
+  ``delivery_status=failed``, which the caller recorded as an end-to-end
+  success.
+
+Each test below fails against the pre-fix implementation.
+"""
+import asyncio
+import json
+import time
+
+import pytest
+from unittest.mock import AsyncMock
+
+from database import db_manager
+from handlers import review
+from telegram.error import RetryAfter
+
+
+@pytest.fixture
+async def review_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "reviews.db")
+    monkeypatch.setattr(db_manager, "DB_PATH", db_path)
+    monkeypatch.setattr(review, "REVIEW_CHAT_ID", -100123)
+    monkeypatch.setattr(review, "ADMIN_IDS", [123456789])
+    await db_manager.init_db()
+    return db_path
+
+
+def _command(key: str) -> "review.QueueCommand":
+    return review.QueueCommand(
+        user_id=7, username="flow", tags="#x", title="", note="", link="",
+        anonymous=False, spoiler=False, source="api",
+        idempotency_key=key, source_ref='{"executionId":"exec-timeout"}',
+        review_chat_id="-100123",
+    )
+
+
+class _Stager:
+    """Minimal StagingPort double with per-test hooks."""
+
+    def __init__(self, *, on_stage=None):
+        self._on_stage = on_stage
+        self.deleted = []
+        self.cleanup = []
+        self.deadline = "unset"
+        self.stages = 0
+
+    def set_staging_deadline(self, deadline):
+        self.deadline = deadline
+
+    async def stage_local(self, files, *, caption, spoiler, message_ids=None):
+        self.stages += 1
+        ids = message_ids if message_ids is not None else []
+        extra = []
+        if self._on_stage is not None:
+            extra = await self._on_stage(ids) or []
+        else:
+            ids.append(10)
+        return [{"type": "photo", "file_id": "P"}], [], ids, extra
+
+    async def stage_file_ids(self, media, documents, *, caption, spoiler,
+                             message_ids=None):
+        self.stages += 1
+        ids = message_ids if message_ids is not None else []
+        if self._on_stage is not None:
+            await self._on_stage(ids)
+        else:
+            ids.append(10)
+        return [{"type": "photo", "file_id": "P"}], [], ids
+
+    async def delete_preview_messages(self, ids):
+        self.deleted.extend(ids or [])
+
+    async def cleanup_files(self, files):
+        self.cleanup.append(files)
+
+    async def send_control_message_id(self, **kwargs):
+        return 11
+
+    async def notify_reused(self, row):
+        self.row = row
+
+
+# ---- Test D: the sweep must not hijack a live request --------------------
+@pytest.mark.asyncio
+async def test_reconciler_does_not_hijack_live_submission(review_db):
+    """A request that is still staging keeps its row and its previews."""
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import ReviewRepository
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_stage(ids):
+        entered.set()
+        await release.wait()            # a genuinely slow Telegram upload
+        ids.append(10)
+        return []
+
+    stager = _Stager(on_stage=slow_stage)
+    service = ReviewQueueService(heartbeat_seconds=0.01)
+    task = asyncio.create_task(
+        service.enqueue(_command("api:9:live"), stager,
+                        media=[{"x": 1}], documents=[])
+    )
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    await asyncio.sleep(0.06)           # several heartbeats while still in flight
+
+    swept = await ReviewQueueService().reconcile_incomplete(
+        _Stager(), stale_seconds=0.03
+    )
+    assert swept == 0, "the sweep repaired a live, heartbeating submission"
+
+    repo = ReviewRepository()
+    row = await repo.find_active_by_key("api:9:live", 0)
+    assert row["status"] == "preparing", "live row was moved by the sweep"
+    assert stager.deleted == [], "live previews were deleted by the sweep"
+
+    release.set()
+    result = await asyncio.wait_for(task, timeout=5)
+    assert result["status"] == "pending_review"
+    assert result["reused"] is False
+    assert stager.deleted == []
+    assert stager.deadline is None, "staging budget leaked past the request"
+
+    rows = await _all_reviews()
+    assert len(rows) == 1, "exactly one review per idempotency key"
+
+
+# ---- Test D (control): a genuinely abandoned row is still repaired -------
+@pytest.mark.asyncio
+async def test_reconciler_still_repairs_abandoned_row(review_db):
+    """No liveness signal => the row really is crash leftovers."""
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+
+    repo = ReviewRepository()
+    rid = await repo.insert(NewReview(
+        idempotency_key="api:9:dead", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False, media=[], documents=[],
+        review_chat_id="-100123", review_message_ids=[55], status="preparing",
+    ))
+
+    await ReviewQueueService().reconcile_incomplete(_Stager(), stale_seconds=0)
+
+    row = await repo.get(rid)
+    assert row["status"] == "failed", "an abandoned row must still be repaired"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_only_renews_preparing_rows(review_db):
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+
+    repo = ReviewRepository()
+    rid = await repo.insert(NewReview(
+        idempotency_key="api:9:heart", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False, media=[{"type": "photo", "file_id": "P"}],
+        documents=[], review_chat_id="-100123", review_message_ids=[10],
+        status="failed",
+    ))
+    assert await repo.touch_preparing(rid) is False, \
+        "a heartbeat must never touch a row that is no longer preparing"
+
+
+# ---- Test A / C: bounded staging, no unbounded synchronous path ---------
+@pytest.mark.asyncio
+async def test_send_throttled_never_starts_an_attempt_without_budget():
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    calls = []
+
+    async def factory():
+        calls.append(1)
+        raise RetryAfter(1)
+
+    stager = TelegramReviewStager(
+        AsyncMock(), -100123, sleep=AsyncMock(), preview_max_attempts=1000
+    )
+    stager.set_staging_deadline(time.monotonic() - 1.0)
+    with pytest.raises(RuntimeError) as err:
+        await stager._send_throttled(factory)
+    assert "timeout" in str(err.value).lower(), \
+        "the deadline error must be classifiable as retryable"
+    assert calls == [], "an attempt started after the staging deadline"
+
+
+@pytest.mark.asyncio
+async def test_send_throttled_stops_at_deadline_instead_of_retrying():
+    """Flood retries must not outlive the budget the router allows."""
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    calls = []
+
+    async def factory():
+        calls.append(1)
+        raise RetryAfter(1)
+
+    stager = TelegramReviewStager(
+        AsyncMock(), -100123, preview_max_attempts=1000
+    )
+    stager.set_staging_deadline(time.monotonic() + 0.05)
+    with pytest.raises(Exception):
+        await stager._send_throttled(factory)
+    assert 0 < len(calls) <= 2, f"unbounded retry: {len(calls)} attempts"
+
+
+@pytest.mark.asyncio
+async def test_timeouts_are_capped_to_remaining_budget():
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    stager = TelegramReviewStager(AsyncMock(), -100123, preview_timeout=120.0)
+    assert stager._timeouts_now() == stager._timeouts      # unbounded by default
+    stager.set_staging_deadline(time.monotonic() + 7.0)
+    capped = stager._timeouts_now()
+    assert 0 < capped["read_timeout"] <= 7.0, "call outlives the request budget"
+    stager.set_staging_deadline(None)
+    assert stager._timeouts_now() == stager._timeouts
+
+
+# ---- Test B: a failed first attempt stays one review, and is not "ok" ----
+@pytest.mark.asyncio
+async def test_deadline_failure_is_coherent_and_never_duplicates(review_db):
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import ReviewRepository
+
+    def _deadline_stage(ids):
+        ids.append(10)
+        raise RuntimeError(
+            "审核预览暂存超时（submission staging timeout），本次投稿未完成"
+        )
+
+    stager = _Stager(on_stage=_deadline_stage)
+    service = ReviewQueueService()
+    with pytest.raises(RuntimeError):
+        await service.enqueue(_command("api:9:deadline"), stager,
+                              media=[{"x": 1}], documents=[])
+
+    repo = ReviewRepository()
+    row = await repo.find_active_by_key("api:9:deadline", 0)
+    assert row["status"] == "failed"
+    assert stager.deleted == [10], "previews must be rolled back"
+    assert stager.deadline is None, "staging budget leaked past the request"
+
+    # Retrying the same key reuses THAT row: one review, never two.
+    retry = await ReviewQueueService().enqueue(
+        _command("api:9:deadline"), _Stager(), media=[{"x": 1}], documents=[]
+    )
+    assert retry["reused"] is True
+    assert retry["review_id"] == row["id"]
+    assert retry["status"] == "failed"
+    assert retry["reuse_reason"] == "idempotent_replay"
+    assert len(await _all_reviews()) == 1
+
+
+@pytest.mark.asyncio
+async def test_server_side_success_makes_an_ambiguous_retry_a_success(review_db):
+    """If the lost 502 hid a real success, the retry must ACK it as one."""
+    from telepost.application.review_queue import ReviewQueueService
+    from telepost.storage.sqlite.reviews import NewReview, ReviewRepository
+
+    repo = ReviewRepository()
+    rid = await repo.insert(NewReview(
+        idempotency_key="api:9:lostack", source="api", user_id=7,
+        username="flow", title="", tags="#x", note="", link="",
+        anonymous=False, spoiler=False,
+        media=[{"type": "photo", "file_id": "P"}], documents=[],
+        review_chat_id="-100123", review_message_ids=[10], status="pending",
+    ))
+
+    class Stager(_Stager):
+        async def notify_reused(self, row):
+            self.row = row
+
+    result = await ReviewQueueService().enqueue(
+        _command("api:9:lostack"), Stager(), media=[{"x": 1}], documents=[]
+    )
+    assert result["reused"] is True
+    assert result["review_id"] == rid
+    assert result["status"] == "pending_review"
+    assert result["delivery_status"] == "pending_review"
+    assert len(await _all_reviews()) == 1
+
+
+def test_reused_failed_review_is_not_reported_as_ok():
+    """The production pair: review 59 (failed) must not look like review 60."""
+    from utils import api_server
+
+    failed = api_server._business_ack({
+        "status": "failed", "review_id": 59, "reused": True,
+        "reuse_reason": "idempotent_replay", "delivery_status": "failed",
+    })
+    body = json.loads(failed.body)
+    assert failed.status == 400, "a reused failed review is not a success"
+    assert body["ok"] is False
+    assert body["data"]["business_status"] == "permanent_failure"
+
+    pending = api_server._business_ack({
+        "status": "pending_review", "review_id": 60, "reused": True,
+        "reuse_reason": "idempotent_replay", "delivery_status": "pending_review",
+    })
+    pending_body = json.loads(pending.body)
+    assert pending.status == 200
+    assert pending_body["ok"] is True
+    assert pending_body["data"]["business_status"] == "idempotent_replay"
+
+
+async def _all_reviews() -> list:
+    async with db_manager.get_db() as conn:
+        cur = await conn.execute("SELECT id, status FROM pending_reviews")
+        return list(await cur.fetchall())

--- a/utils/api_server.py
+++ b/utils/api_server.py
@@ -126,16 +126,34 @@ _BUSINESS_STATUS = {
 }
 
 
+# Terminal remote review states. They must never be reported as an accepted
+# delivery, and retrying the same idempotency key can only return the same row.
+_FAILED_DELIVERY_STATUSES = ("failed", "rejected", "invalid", "expired")
+
+
+def _is_failed_status(status) -> bool:
+    return str(status or "").strip().lower() in _FAILED_DELIVERY_STATUSES
+
+
 def _business_ack(result: dict) -> web.Response:
     """Normalize a facade result dict to the formal business ACK envelope."""
     reason = result.get("reuse_reason") or ""
-    if reason == "idempotent_replay":
+    if reason == "idempotent_replay" and _is_failed_status(result.get("status")):
+        # A reuse only ACKs successfully when the REUSED RECORD is itself on the
+        # success path. Reporting a reused `failed` record as 200 /
+        # idempotent_replay told callers "already accepted" for a submission
+        # that never reached the review queue, so a downstream failure was
+        # recorded as an end-to-end success by the client. The row is terminal
+        # for this idempotency key (a retry returns the same failed record).
+        business = "permanent_failure"
+        http_status = 400
+    elif reason == "idempotent_replay":
         business = "idempotent_replay"
         http_status = 200
     elif reason == "duplicate_existing":
         business = "duplicate_existing"
         http_status = 200
-    elif result.get("status") in ("failed",):
+    elif _is_failed_status(result.get("status")):
         business = "permanent_failure"
         http_status = 400
     else:


### PR DESCRIPTION
Production evidence (review #59, 2026-09-12) and the three fixes are described in the commit message.

Root cause: an in-flight submission is indistinguishable from crash leftovers (`status='preparing'` + `control_message_id IS NULL`), so the 60s reconciliation sweep deleted the previews of a live request and marked the review `failed`; the router then answered 502 at its 300s timeout, and the reuse path reported the failed row as `ok: true`.

- `ReviewRepository.touch_preparing` + heartbeat in `ReviewQueueService.enqueue`
- `TelegramReviewStager.set_staging_deadline` (240s budget < router 300s)
- `_business_ack` no longer ACKs a reused terminal-failure row

Regression tests: `tests/test_submission_timeout_idempotency.py` (9 tests, all fail pre-fix).