### PR TITLE
docs(release): refresh download page to v2.17.5

### DIFF
--- a/.release-policy.yml
+++ b/.release-policy.yml
@@ -48,7 +48,7 @@
     }
   },
   "release": {
-    "post_publish": "python3 .github/scripts/update_download_page.py && git config user.name github-actions[bot] && git config user.email 41898282+github-actions[bot]@users.noreply.github.com && git add docs/download.md && (git diff --cached --quiet || (git commit -m 'docs: update release download page' && git push))"
+    "post_publish": "python3 .github/scripts/update_download_page.py && git config user.name github-actions[bot] && git config user.email 41898282+github-actions[bot]@users.noreply.github.com && git add docs/download.md docs/en/download.md && (git diff --cached --quiet || (git commit -m 'docs: update release download page' && git push))"
   },
   "retention": {
     "stable": 1,

--- a/docs/en/download.md
+++ b/docs/en/download.md
@@ -4,17 +4,17 @@
 
 This page is **generated automatically** by GitHub Actions on every release and always points at the latest one.
 
-## Latest version: `v2.17.2` (2026-09-10)
+## Latest version: `v2.17.5` (2026-09-12)
 
-👉 [Release notes and checksums](https://github.com/redtidev1918/TelePost/releases/tag/v2.17.2)
+👉 [Release notes and checksums](https://github.com/redtidev1918/TelePost/releases/tag/v2.17.5)
 
 | Platform | File | Size | Download |
 |---|---|---|---|
-| Linux · x64 | `telepost-2.17.2-linux-x64.tar.gz` | 31.8 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/telepost-2.17.2-linux-x64.tar.gz) |
-| Linux · x64 | `telepost-linux-x64` | 32.1 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/telepost-linux-x64) |
-| Windows · x64 | `telepost-2.17.2-windows-x64.zip` | 20.3 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/telepost-2.17.2-windows-x64.zip) |
-| Windows · x64 | `telepost-windows-x64.exe` | 20.6 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/telepost-windows-x64.exe) |
-| macOS · arm64 | `telepost-2.17.2-macos-arm64.tar.gz` | 17.1 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/telepost-2.17.2-macos-arm64.tar.gz) |
-| macOS · arm64 | `telepost-macos-arm64` | 17.3 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/telepost-macos-arm64) |
-| All platforms | `RELEASE-METADATA.json` | 3 KB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/RELEASE-METADATA.json) |
-| All platforms | `SHA256SUMS` | 1 KB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.2/SHA256SUMS) |
+| Linux · x64 | `telepost-2.17.5-linux-x64.tar.gz` | 31.8 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/telepost-2.17.5-linux-x64.tar.gz) |
+| Linux · x64 | `telepost-linux-x64` | 32.1 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/telepost-linux-x64) |
+| Windows · x64 | `telepost-2.17.5-windows-x64.zip` | 20.3 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/telepost-2.17.5-windows-x64.zip) |
+| Windows · x64 | `telepost-windows-x64.exe` | 20.6 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/telepost-windows-x64.exe) |
+| macOS · arm64 | `telepost-2.17.5-macos-arm64.tar.gz` | 17.1 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/telepost-2.17.5-macos-arm64.tar.gz) |
+| macOS · arm64 | `telepost-macos-arm64` | 17.3 MB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/telepost-macos-arm64) |
+| All platforms | `RELEASE-METADATA.json` | 3 KB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/RELEASE-METADATA.json) |
+| All platforms | `SHA256SUMS` | 1 KB | [⬇️ Download](https://github.com/redtidev1918/TelePost/releases/download/v2.17.5/SHA256SUMS) |


### PR DESCRIPTION
## What

- Regenerate `docs/en/download.md` so it points at the current release (v2.17.5) instead of v2.17.2.
- Fix the cause: the `release.post_publish` hook runs `update_download_page.py`, which writes **both** locales, but only staged `docs/download.md` in git — so the English page silently drifted while the Chinese one tracked every release.

## Evidence

| | before | after |
|---|---|---|
| `docs/download.md` | v2.17.5 | v2.17.5 (unchanged) |
| `docs/en/download.md` | v2.17.2 | v2.17.5 |

`docs/download.md` is byte-identical after re-running the generator, which confirms the generator is the canonical producer and this change is purely the dropped locale.

## Scope

Documentation + release-policy hook only. No runtime code, no version bump, no release.