### PR TITLE
fix(delivery): 依据最终产物分类媒体，让压缩后达标的大图回到 photo 而不是 document

### DIFF
--- a/telepost/telegram/delivery/executor.py
+++ b/telepost/telegram/delivery/executor.py
@@ -16,14 +16,19 @@ An album failure that is *not* a network error falls back to one-by-one sends
 """
 from __future__ import annotations
 
+import os
 from typing import Callable, List, Optional, Protocol
 
 from ...domain.delivery import (
     DeliveredMessage,
     DeliveryResult,
+    LocalFile,
+    MediaItem,
+    MediaKind,
     ReplyMode,
 )
 from .planner import Batch, DeliveryPlan
+from .preparation import is_photo_constraint_error, retry_photo_derivative
 
 
 class NetworkFailure(Exception):
@@ -52,6 +57,50 @@ class Sender(Protocol):
 
 
 OnSent = Callable[[List[DeliveredMessage]], None]
+
+
+async def _recover_rejected_photo(sender: "Sender", item, *,
+                                  reply_to: Optional[int],
+                                  caption: Optional[str]):
+    """ONE bounded re-process of a photo Telegram itself rejected.
+
+    Telegram's verdict is the authority (the artifact already passed local
+    validation), so a refused photo gets exactly one smaller derivative and one
+    retry as a photo; only if that is refused too does the artwork ship as a
+    document instead of failing the whole delivery. Any other error propagates
+    untouched. May raise :class:`NetworkFailure` from the retry itself.
+    """
+    path = item.local_path
+    if item.kind is not MediaKind.PHOTO or not path:
+        return None
+    derivative = retry_photo_derivative(path)
+    if derivative is None:
+        return None
+    name = f"{os.path.splitext(item.filename or 'image')[0]}.jpg"
+    retry_item = MediaItem(
+        MediaKind.PHOTO,
+        LocalFile(derivative, name, original_path=path, temporary=True),
+        item.spoiler,
+    )
+    try:
+        try:
+            return await sender.send_single(retry_item, reply_to=reply_to,
+                                            caption=caption)
+        except NetworkFailure:
+            raise
+        except Exception:
+            document = MediaItem(
+                MediaKind.DOCUMENT,
+                LocalFile(path, item.filename or "file", original_path=path),
+                False,
+            )
+            return await sender.send_single(document, reply_to=reply_to,
+                                            caption=caption)
+    finally:
+        try:
+            os.unlink(derivative)
+        except OSError:
+            pass
 
 
 async def execute_plan(
@@ -133,6 +182,25 @@ async def execute_plan(
                     result.error = getattr(exc, "original", None) or exc
                     return result
                 except Exception as exc:
+                    recovered = None
+                    if is_photo_constraint_error(exc):
+                        try:
+                            recovered = await _recover_rejected_photo(
+                                sender, item, reply_to=item_reply,
+                                caption=item_caption,
+                            )
+                        except NetworkFailure as net_exc:
+                            result = DeliveryResult.uncertain(
+                                "photo retry response lost; Telegram may have "
+                                "accepted it",
+                                known_messages=sent + messages,
+                            )
+                            result.error = (getattr(net_exc, "original", None)
+                                            or net_exc)
+                            return result
+                    if recovered is not None:
+                        messages.append(recovered)
+                        continue
                     # Certain failure with known landed messages; the caller
                     # decides rollback/retry without guessing delivery state.
                     return DeliveryResult.failed(

--- a/telepost/telegram/delivery/planner.py
+++ b/telepost/telegram/delivery/planner.py
@@ -12,10 +12,14 @@ Turns an ordered list of :class:`MediaItem` into concrete send batches:
 Two orderings are supported because channel delivery and review-chat preview
 historically differ:
 
+* ``INPUT``  – **default**: keep the original artwork order and split it into
+  maximal same-family runs. Telegram only forces a split when a family genuinely
+  cannot share a media group (animation/audio are never album members, and
+  documents are only homogeneous with documents), so a gallery whose items are
+  all photos stays one ordered album instead of being regrouped into "photos
+  first, documents last";
 * ``FAMILY`` – stable family order visual → animation → audio → document, used
-  by channel publishing (preserves ``handlers.publish._item_batches``);
-* ``INPUT``  – split the input order into maximal same-family runs, used by the
-  review-chat preview (preserves original upload order).
+  by channel publishing (preserves ``handlers.publish._item_batches``).
 """
 from __future__ import annotations
 
@@ -37,7 +41,10 @@ ALBUM_FAMILIES = {
     MediaKind.VIDEO: "visual",
     MediaKind.DOCUMENT: "document",
 }
-FAMILY_ORDER = {"visual": 0, MediaKind.ANIMATION: 1, MediaKind.AUDIO: 2, "document": 3}
+#: Family keys are the plain strings returned by :func:`family_of` (a
+#: ``MediaKind`` member is a ``str`` subclass, so mixing both shapes only works
+#: by accident of str-mixin hashing — keep this dict string-only).
+FAMILY_ORDER = {"visual": 0, "animation": 1, "audio": 2, "document": 3}
 
 
 def family_of(kind: MediaKind) -> str:
@@ -104,8 +111,12 @@ def _chunk_runs(ordering: PlanningOrder, items: List[MediaItem],
 def plan_delivery(items: List[MediaItem], *, album_size: int = 10,
                   reply_mode: ReplyMode = ReplyMode.CHAIN,
                   anchor_message_id: Optional[int] = None,
-                  ordering: PlanningOrder = PlanningOrder.FAMILY) -> DeliveryPlan:
-    """Partition items into batches; album-capable runs longer than one become albums."""
+                  ordering: PlanningOrder = PlanningOrder.INPUT) -> DeliveryPlan:
+    """Partition items into batches; album-capable runs longer than one become albums.
+
+    The default ``INPUT`` ordering keeps the artwork order the submitter sent:
+    items only leave their run when Telegram forbids sharing a media group.
+    """
     if album_size < 1:
         raise ValueError("album_size must be >= 1")
     batches: List[Batch] = []

--- a/telepost/telegram/delivery/preparation.py
+++ b/telepost/telegram/delivery/preparation.py
@@ -1,10 +1,26 @@
 """Canonical, decode-budgeted media preparation.
 
 Every local-photo path (review staging, direct/channel publishing, discussion
-publishing and replay) reaches this module before Telegram I/O.  Probing reads
-only file metadata.  A photo whose estimated working set exceeds the configured
-budget is never decoded: an optional preview is used, otherwise the immutable
-original is sent as a document.
+publishing and replay) reaches this module before Telegram I/O.  The pipeline is:
+
+    probe (header only, no pixel decode)
+      -> decide the target kind from the PROBE + source metadata
+      -> transform only when necessary (bounded, memory-safe)
+      -> validate the FINAL artifact (bytes AND dimensions AND ratio AND format)
+      -> re-classify from the FINAL artifact
+      -> PreparedMedia with an explicit fallback reason
+
+Telegram photo constraints, from https://core.telegram.org/bots/api#sendphoto :
+
+* "The photo must be at most 10 MB in size."
+* "The photo's width and height must not exceed 10000 in total."
+* "Width and height ratio must be at most 20."
+
+``sendMediaGroup`` re-uses the same photo pipeline (2-10 items, documents and
+audio only alongside their own type); ``sendAnimation``/``sendDocument`` allow
+"up to 50 MB in size".  Those numbers are the only source of truth here — a
+dimension violation is *not* a reason to send a document, it is a reason to
+produce a smaller photo.
 
 Pure filesystem + Pillow, no PTB imports.
 """
@@ -15,22 +31,63 @@ import logging
 import mimetypes
 import os
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from ...domain.delivery import LocalFile, MediaItem, MediaKind
 
 logger = logging.getLogger(__name__)
 
-#: Telegram photo (single and in-album) hard limit, with safety margin.
+#: Telegram photo byte limit with a safety margin (see module docstring).
 PHOTO_MAX_BYTES = int((10.0 - 0.5) * 1024 * 1024)
 #: Telegram rejects a photo when width + height exceeds this sum, even when the
 #: file is well under the byte limit ("Photo_invalid_dimensions").
 PHOTO_MAX_DIMENSION_SUM = int(os.getenv("TELEPOST_PHOTO_MAX_DIMENSION_SUM", "10000"))
+#: Telegram also rejects extreme panoramas: width/height ratio must be <= 20.
+PHOTO_MAX_ASPECT_RATIO = float(os.getenv("TELEPOST_PHOTO_MAX_ASPECT_RATIO", "20"))
+#: Long-edge cap for a photo derivative; keeps one encode bounded on a small box.
+PHOTO_MAX_EDGE = int(os.getenv("TELEPOST_PHOTO_MAX_EDGE", "4096"))
+#: sendAnimation / sendDocument: "Bots can currently send files ... of up to
+#: 50 MB in size".
+MEDIA_MAX_BYTES = int(float(os.getenv("TELEPOST_MEDIA_MAX_MB", "50")) * 1024 * 1024)
 IMAGE_DECODE_BUDGET_BYTES = max(
     1, int(os.getenv("TELEPOST_IMAGE_DECODE_BUDGET_MB", "64"))
 ) * 1024 * 1024
+#: How many images may be prepared at once. 1 = strictly sequential (low-memory
+#: default, one decoded image in RAM at a time). Higher values only shorten wall
+#: time; they never raise the per-image peak.
+MEDIA_PREPARE_CONCURRENCY = max(
+    1, int(os.getenv("TELEPOST_MEDIA_PREPARE_CONCURRENCY", "1"))
+)
+
+#: Formats Telegram accepts for a photo upload.
+PHOTO_ARTIFACT_FORMATS = frozenset({"JPEG", "MPO", "PNG", "WEBP", "BMP"})
+#: Formats Pillow can decode at a reduced scale (Image.draft), which is what
+#: keeps the peak working set bounded for the huge-JPEG case.
+DRAFT_DECODE_FORMATS = frozenset({"JPEG", "MPO"})
+#: Quality ladder, highest first: never ship a lower quality than necessary.
+JPEG_QUALITIES = (85, 75, 65, 55)
+#: Long-edge ladder used after the dimension-derived cap.
+PHOTO_EDGE_LADDER = (4096, 3200, 2560, 2048, 1600)
+#: Marker substrings of the Telegram errors that mean "this photo is not a
+#: legal photo" (dimensions / ratio / size). Only those justify one bounded
+#: re-process; everything else is a real failure.
+PHOTO_CONSTRAINT_ERROR_MARKERS = (
+    "photo_invalid_dimensions",
+    "invalid_dimensions",
+    "photo dimensions",
+    "width and height",
+    "aspect ratio",
+    "photo_invalid_ratio",
+    "photo_invalid_size",
+    "photo_too_big",
+    "file is too big",
+    "file is too large",
+    "photo is too big",
+    "image_process_failed",
+)
 
 _MODE_BYTES_PER_PIXEL = {
     "1": 1,
@@ -50,6 +107,7 @@ class PreparationDecision(str, Enum):
     PASS_THROUGH = "pass_through"
     SAFE_COMPRESS = "safe_compress"
     USE_PREVIEW = "use_preview"
+    ANIMATION_PRESERVED = "animation_preserved"
     DOCUMENT_FALLBACK = "document_fallback"
 
 
@@ -67,6 +125,53 @@ class MediaProbe:
 class MediaResourceEstimate:
     estimated_decode_bytes: int
     estimated_peak_bytes: int
+
+
+@dataclass(frozen=True)
+class PhotoLimits:
+    """The documented Telegram photo constraints plus the local decode budget."""
+
+    max_bytes: int = PHOTO_MAX_BYTES
+    max_dimension_sum: int = PHOTO_MAX_DIMENSION_SUM
+    max_aspect_ratio: float = PHOTO_MAX_ASPECT_RATIO
+    max_edge: int = PHOTO_MAX_EDGE
+    decode_budget_bytes: int = IMAGE_DECODE_BUDGET_BYTES
+
+
+@dataclass(frozen=True)
+class MediaArtifact:
+    """A concrete file on disk, exactly as Telegram would receive it.
+
+    Classification is always decided from an artifact (source or derivative),
+    never from a mixture of the two.
+    """
+
+    path: str
+    size: int
+    width: int
+    height: int
+    format: str
+
+    @property
+    def dimension_sum(self) -> int:
+        return self.width + self.height
+
+    @property
+    def aspect_ratio(self) -> float:
+        shorter = max(1, min(self.width, self.height))
+        return max(self.width, self.height) / shorter
+
+    def photo_violation(self, limits: PhotoLimits) -> Optional[str]:
+        """Return the first violated photo constraint, or None when it is legal."""
+        if self.format.upper() not in PHOTO_ARTIFACT_FORMATS:
+            return "photo_format_unsupported"
+        if self.dimension_sum > limits.max_dimension_sum:
+            return "photo_dimensions_exceeded"
+        if self.aspect_ratio > limits.max_aspect_ratio:
+            return "photo_aspect_ratio_exceeded"
+        if self.size > limits.max_bytes:
+            return "photo_bytes_exceeded"
+        return None
 
 
 @dataclass(frozen=True)
@@ -90,8 +195,22 @@ def _decision_payload(path: str, *, size: int, decision: str, reason: str,
                       estimate: Optional[MediaResourceEstimate] = None,
                       policy: Optional["MediaPreparationPolicy"] = None,
                       delivery: Optional[str] = None,
-                      preview_available: bool = False) -> Dict[str, Any]:
+                      preview_available: bool = False,
+                      final: Optional[MediaArtifact] = None,
+                      target_kind: Optional[str] = None,
+                      violation: Optional[str] = None,
+                      fallback_reason: Optional[str] = None) -> Dict[str, Any]:
+    """One log line that can reconstruct the whole classification."""
     mime = mimetypes.guess_type(path)[0] or ""
+    if final is None and delivery and delivery != path:
+        try:
+            final = artifact_of(delivery)
+        except Exception:
+            final = None
+    resized = bool(
+        final is not None and probe is not None
+        and (final.width, final.height) != (probe.width, probe.height)
+    )
     payload: Dict[str, Any] = {
         "filename": os.path.basename(path),
         "mime": mime,
@@ -99,6 +218,8 @@ def _decision_payload(path: str, *, size: int, decision: str, reason: str,
         "width": probe.width if probe else None,
         "height": probe.height if probe else None,
         "mode": probe.mode if probe else None,
+        "frames": probe.frames if probe else None,
+        "original_format": probe.format if probe else None,
         "estimated_decode_bytes": (
             estimate.estimated_decode_bytes if estimate else None
         ),
@@ -110,12 +231,18 @@ def _decision_payload(path: str, *, size: int, decision: str, reason: str,
         "decision": decision,
         "reason": reason,
         "original_bytes": size,
+        # ---- final-artifact verdict ----
+        "target_kind": target_kind,
+        "final_bytes": final.size if final else None,
+        "final_width": final.width if final else None,
+        "final_height": final.height if final else None,
+        "final_format": final.format if final else None,
+        "resized": resized,
+        "violation": violation,
+        "fallback_reason": fallback_reason,
     }
-    if delivery and delivery != path:
-        try:
-            payload["prepared_bytes"] = os.stat(delivery).st_size
-        except OSError:
-            pass
+    if final is not None and final.path != path:
+        payload["prepared_bytes"] = final.size
     return payload
 
 
@@ -136,6 +263,18 @@ def probe_image(path: str) -> MediaProbe:
         )
 
 
+def artifact_of(path: str, *, probe: Optional[MediaProbe] = None) -> MediaArtifact:
+    """Header-only view of a file as Telegram would receive it."""
+    probe = probe or probe_image(path)
+    return MediaArtifact(
+        path=path,
+        size=os.stat(path).st_size,
+        width=probe.width,
+        height=probe.height,
+        format=probe.format,
+    )
+
+
 def estimate_resources(probe: MediaProbe) -> MediaResourceEstimate:
     pixels = probe.width * probe.height
     decode = pixels * _MODE_BYTES_PER_PIXEL.get(probe.mode, 4)
@@ -143,79 +282,181 @@ def estimate_resources(probe: MediaProbe) -> MediaResourceEstimate:
     return MediaResourceEstimate(decode, decode + conversion)
 
 
+def is_photo_constraint_error(error: object) -> bool:
+    """True when a Telegram error means "this file is not a legal photo"."""
+    text = str(error or "").lower()
+    return any(marker in text for marker in PHOTO_CONSTRAINT_ERROR_MARKERS)
+
+
+def _unlink(path: Optional[str]) -> None:
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _artifact_is_compliant(path: str, limits: PhotoLimits) -> bool:
+    try:
+        return artifact_of(path).photo_violation(limits) is None
+    except Exception:
+        return False
+
+
 class MediaPreparationPolicy:
     def __init__(self, *, max_bytes: int = PHOTO_MAX_BYTES,
-                 decode_budget_bytes: int = IMAGE_DECODE_BUDGET_BYTES):
-        self.max_bytes = max_bytes
-        self.decode_budget_bytes = decode_budget_bytes
+                 decode_budget_bytes: int = IMAGE_DECODE_BUDGET_BYTES,
+                 limits: Optional[PhotoLimits] = None):
+        self.limits = limits or PhotoLimits(
+            max_bytes=max_bytes, decode_budget_bytes=decode_budget_bytes
+        )
+        self.max_bytes = self.limits.max_bytes
+        self.decode_budget_bytes = self.limits.decode_budget_bytes
 
     def prepare(self, path: str, *, preview_path: Optional[str] = None) -> PreparedMedia:
         try:
             size = os.stat(path).st_size
         except OSError:
-            return self._fallback(path, preview_path, reason="compression_failed_fallback")
-
-        # Telegram can accept this exact file as a photo; no decode is needed.
-        # This also keeps normal operation working without PIL.
-        if size <= self.max_bytes:
-            # Bytes alone are not sufficient: Telegram rejects photos whose
-            # width+height exceeds PHOTO_MAX_DIMENSION_SUM with
-            # "Photo_invalid_dimensions". Header-only probe (no pixel decode);
-            # an unreadable header keeps the pass-through behaviour.
-            try:
-                probe = probe_image(path)
-            except Exception:
-                probe = None
-            if probe is not None and \
-                    probe.width + probe.height > PHOTO_MAX_DIMENSION_SUM:
-                return self._fallback(
-                    path, preview_path, probe=probe,
-                    reason="photo_dimensions_too_large",
-                )
-            payload = _decision_payload(
-                path, size=size, decision="photo_passthrough",
-                reason="already_within_limits", policy=self, probe=probe,
-            )
-            log_media_decision(payload)
-            return PreparedMedia(path, path, MediaKind.PHOTO,
-                                 PreparationDecision.PASS_THROUGH,
-                                 decision=payload)
+            return self._fallback(path, preview_path, reason="source_unreadable")
 
         try:
             probe = probe_image(path)
-            estimate = estimate_resources(probe)
         except Exception:
-            return self._fallback(path, preview_path)
+            probe = None
+        estimate = estimate_resources(probe) if probe is not None else None
 
-        if probe.frames > 1 or estimate.estimated_peak_bytes > self.decode_budget_bytes:
+        # ---- 1. animations are never photo material -------------------
+        if probe is not None and probe.frames > 1:
+            return self._animated(path, size=size, probe=probe, estimate=estimate)
+
+        # ---- 2. header-only decision on the immutable original --------
+        if probe is None:
+            if size <= self.max_bytes:
+                # Unreadable header: keep the historical lenient pass-through
+                # (also keeps normal operation working without PIL).
+                return self._emit(
+                    path, path, MediaKind.PHOTO, PreparationDecision.PASS_THROUGH,
+                    size=size, decision="photo_passthrough",
+                    reason="already_within_limits", target_kind=MediaKind.PHOTO.value,
+                )
+            return self._fallback(path, preview_path, reason="probe_failed")
+
+        original = MediaArtifact(path, size, probe.width, probe.height, probe.format)
+        violation = original.photo_violation(self.limits)
+        if violation is None:
+            return self._emit(
+                path, path, MediaKind.PHOTO, PreparationDecision.PASS_THROUGH,
+                size=size, decision="photo_passthrough",
+                reason="already_within_limits", probe=probe, estimate=estimate,
+                final=original, target_kind=MediaKind.PHOTO.value,
+            )
+
+        # ---- 3. bounded, memory-safe transform ------------------------
+        if not self._decode_is_bounded(probe, estimate):
+            # Peak working set cannot be bounded for this format (no reduced
+            # decode available) — a routing decision, not a silent loss.
             return self._fallback(
                 path, preview_path, probe=probe, estimate=estimate,
-                reason="decode_budget_exceeded",
+                reason="decode_budget_exceeded", violation=violation,
             )
 
-        derivative = compress_photo(path, self.max_bytes)
-        if derivative:
-            payload = _decision_payload(
-                path, size=size, decision="safe_compress",
-                reason="photo_size_exceeded_but_decode_within_budget",
-                probe=probe, estimate=estimate, policy=self,
-                delivery=derivative,
-                preview_available=bool(preview_path),
+        if violation == "photo_aspect_ratio_exceeded":
+            # A uniform downscale preserves the ratio, so no compliant photo is
+            # reachable without cropping the artwork.
+            return self._fallback(
+                path, preview_path, probe=probe, estimate=estimate,
+                reason="photo_aspect_ratio_unfixable", violation=violation,
             )
-            log_media_decision(payload)
-            return PreparedMedia(path, derivative, MediaKind.PHOTO,
-                                 PreparationDecision.SAFE_COMPRESS, True,
-                                 decision=payload)
+
+        derivative = compress_photo(
+            path, self.max_bytes, probe=probe, limits=self.limits
+        )
+
+        # ---- 4. re-classify from the FINAL artifact -------------------
+        final: Optional[MediaArtifact] = None
+        if derivative:
+            try:
+                final = artifact_of(derivative)
+            except Exception:
+                final = None
+            if final is None or final.photo_violation(self.limits) is not None:
+                _unlink(derivative)
+                derivative, final = None, None
+        if derivative and final is not None:
+            reason = (
+                "photo_size_exceeded_but_decode_within_budget"
+                if violation == "photo_bytes_exceeded"
+                else "photo_dimensions_too_large_resized"
+            )
+            return self._emit(
+                path, derivative, MediaKind.PHOTO,
+                PreparationDecision.SAFE_COMPRESS, size=size,
+                decision="safe_compress", reason=reason, probe=probe,
+                estimate=estimate, final=final,
+                violation=violation, target_kind=MediaKind.PHOTO.value,
+                preview_available=bool(preview_path), temporary=True,
+            )
         return self._fallback(
             path, preview_path, probe=probe, estimate=estimate,
-            reason="compression_failed_fallback",
+            reason="photo_transform_failed", violation=violation,
         )
+
+    # ---- helpers -------------------------------------------------------
+    def _decode_is_bounded(self, probe: MediaProbe,
+                           estimate: MediaResourceEstimate) -> bool:
+        if estimate.estimated_peak_bytes <= self.decode_budget_bytes:
+            return True
+        # Image.draft() drops DCT blocks before allocating pixels, so a huge
+        # JPEG still decodes inside the budget at a reduced scale.
+        return probe.format.upper() in DRAFT_DECODE_FORMATS
+
+    def _animated(self, path: str, *, size: int, probe: MediaProbe,
+                  estimate: MediaResourceEstimate) -> PreparedMedia:
+        """Keep the animation: never route animated content through the JPEG ladder."""
+        if size <= MEDIA_MAX_BYTES:
+            return self._emit(
+                path, path, MediaKind.ANIMATION,
+                PreparationDecision.ANIMATION_PRESERVED, size=size,
+                decision="animation_kept", reason="animated_never_static",
+                probe=probe, estimate=estimate,
+                target_kind=MediaKind.ANIMATION.value,
+                final=MediaArtifact(path, size, probe.width, probe.height,
+                                    probe.format),
+            )
+        return self._emit(
+            path, path, MediaKind.DOCUMENT, PreparationDecision.DOCUMENT_FALLBACK,
+            size=size, decision="document_fallback",
+            reason="animation_exceeds_animation_byte_limit", probe=probe,
+            estimate=estimate, target_kind=MediaKind.DOCUMENT.value,
+            fallback_reason="animation_exceeds_animation_byte_limit",
+        )
+
+    def _emit(self, source: str, delivery: str, kind: MediaKind,
+              decision_enum: PreparationDecision, *, size: int, decision: str,
+              reason: str, probe: Optional[MediaProbe] = None,
+              estimate: Optional[MediaResourceEstimate] = None,
+              final: Optional[MediaArtifact] = None,
+              preview_available: bool = False, violation: Optional[str] = None,
+              fallback_reason: Optional[str] = None,
+              target_kind: Optional[str] = None,
+              temporary: bool = False) -> PreparedMedia:
+        payload = _decision_payload(
+            source, size=size, decision=decision, reason=reason, probe=probe,
+            estimate=estimate, policy=self, delivery=delivery,
+            preview_available=preview_available,
+            final=final, target_kind=target_kind,
+            violation=violation, fallback_reason=fallback_reason,
+        )
+        log_media_decision(payload)
+        return PreparedMedia(source, delivery, kind, decision_enum, temporary,
+                             decision=payload)
 
     def _fallback(self, path: str, preview_path: Optional[str], *,
                   reason: str = "decode_budget_exceeded",
                   probe: Optional[MediaProbe] = None,
-                  estimate: Optional[MediaResourceEstimate] = None
-                  ) -> PreparedMedia:
+                  estimate: Optional[MediaResourceEstimate] = None,
+                  violation: Optional[str] = None) -> PreparedMedia:
         try:
             size = os.stat(path).st_size
         except OSError:
@@ -223,93 +464,205 @@ class MediaPreparationPolicy:
         if preview_path:
             try:
                 if os.stat(preview_path).st_size <= self.max_bytes:
-                    payload = _decision_payload(
-                        path, size=size, decision="use_preview",
+                    preview_probe = None
+                    try:
+                        preview_probe = probe_image(preview_path)
+                    except Exception:
+                        preview_probe = None
+                    preview_final = None
+                    if preview_probe is not None:
+                        preview_final = MediaArtifact(
+                            preview_path, os.stat(preview_path).st_size,
+                            preview_probe.width, preview_probe.height,
+                            preview_probe.format,
+                        )
+                    return self._emit(
+                        path, preview_path, MediaKind.PHOTO,
+                        PreparationDecision.USE_PREVIEW, size=size,
+                        decision="use_preview",
                         reason="preview_preferred"
                         if reason == "decode_budget_exceeded"
                         else "compression_failed_fallback",
-                        probe=probe, estimate=estimate, policy=self,
-                        delivery=preview_path, preview_available=True,
-                    )
-                    log_media_decision(payload)
-                    return PreparedMedia(
-                        path, preview_path, MediaKind.PHOTO,
-                        PreparationDecision.USE_PREVIEW, decision=payload,
+                        probe=probe, estimate=estimate, preview_available=True,
+                        final=preview_final, violation=violation,
+                        target_kind=MediaKind.PHOTO.value,
                     )
             except OSError:
                 pass
-        payload = _decision_payload(
-            path, size=size, decision="document_fallback", reason=reason,
-            probe=probe, estimate=estimate, policy=self,
-            preview_available=bool(preview_path),
+        return self._emit(
+            path, path, MediaKind.DOCUMENT, PreparationDecision.DOCUMENT_FALLBACK,
+            size=size, decision="document_fallback", reason=reason, probe=probe,
+            estimate=estimate, preview_available=bool(preview_path),
+            violation=violation, fallback_reason=reason,
+            target_kind=MediaKind.DOCUMENT.value,
         )
-        log_media_decision(payload)
-        return PreparedMedia(path, path, MediaKind.DOCUMENT,
-                             PreparationDecision.DOCUMENT_FALLBACK,
-                             decision=payload)
 
 
-def compress_photo(path: str, max_bytes: int) -> Optional[str]:
-    """Create a bounded JPEG derivative; the original is never modified."""
+def _scaled_size(size: Tuple[int, int], cap: int) -> Tuple[int, int]:
+    width, height = size
+    longest = max(width, height)
+    if cap >= longest:
+        return width, height
+    factor = cap / longest
+    return max(1, int(width * factor)), max(1, int(height * factor))
+
+
+def photo_dimension_caps(probe: MediaProbe, limits: PhotoLimits) -> List[int]:
+    """Long-edge caps to try, largest (highest quality) first.
+
+    The first cap is the largest one that still satisfies the documented
+    dimension-sum rule, so a high-resolution-but-small-bytes image is resized
+    just enough instead of being dropped to the smallest ladder step.
+    """
+    longest = max(probe.width, probe.height)
+    first = min(longest, limits.max_edge)
+    if probe.width + probe.height > limits.max_dimension_sum:
+        allowed = (limits.max_dimension_sum * longest) // (probe.width + probe.height)
+        first = min(first, max(1, allowed))
+    ladder = [first]
+    for cap in PHOTO_EDGE_LADDER:
+        if cap < first and cap not in ladder:
+            ladder.append(cap)
+    return ladder
+
+
+def _save_jpeg(image, directory: str, quality: int) -> Optional[str]:
+    fd, derivative = tempfile.mkstemp(
+        prefix="telepost-prepared-", suffix=".jpg", dir=directory
+    )
+    os.close(fd)
+    try:
+        image.save(derivative, "JPEG", quality=quality)
+    except Exception as exc:
+        logger.warning("图片压缩失败: %s", exc)
+        _unlink(derivative)
+        return None
+    return derivative
+
+
+def compress_photo(path: str, max_bytes: int, *,
+                   probe: Optional[MediaProbe] = None,
+                   limits: Optional[PhotoLimits] = None,
+                   dimension_caps: Optional[Sequence[int]] = None) -> Optional[str]:
+    """Bounded quality → dimension → format ladder; the original is never modified.
+
+    Returns a JPEG derivative whose FINAL artifact satisfies every Telegram photo
+    constraint (bytes, dimension sum, ratio, format), or ``None`` when no
+    compliant derivative is reachable.  One image is decoded at a time and every
+    intermediate buffer is released before the next attempt.
+    """
     try:
         from PIL import Image
     except ImportError:
         return None
 
-    derivative = ""
-    try:
-        with Image.open(path) as source:
-            image = source
-            converted = None
-            # Shrink before RGB conversion so RGBA does not create a second
-            # full-size pixel buffer. Only budget-approved images reach here.
-            if max(image.size) > 4096:
-                image.thumbnail((4096, 4096), Image.Resampling.LANCZOS)
-            if image.mode not in ("RGB", "L"):
-                converted = image.convert("RGB")
-                image = converted
-            try:
-                for quality in (85, 70, 55):
-                    fd, derivative = tempfile.mkstemp(
-                        prefix="telepost-prepared-", suffix=".jpg",
-                        dir=os.path.dirname(os.path.abspath(path)),
-                    )
-                    os.close(fd)
-                    image.save(derivative, "JPEG", quality=quality)
-                    if os.stat(derivative).st_size <= max_bytes:
-                        return derivative
-                    os.unlink(derivative)
-                    derivative = ""
-            finally:
-                if converted is not None:
-                    converted.close()
-    except Exception as exc:  # decoding/IO failure → caller falls back to document
-        logger.warning("图片压缩失败，回退为文档发送: %s", exc)
-    if derivative:
+    limits = limits or PhotoLimits(max_bytes=max_bytes)
+    if probe is None:
         try:
-            os.unlink(derivative)
-        except OSError:
-            pass
+            probe = probe_image(path)
+        except Exception:
+            return None
+
+    caps = list(dimension_caps) if dimension_caps else photo_dimension_caps(probe, limits)
+    directory = os.path.dirname(os.path.abspath(path))
+    for cap in caps:
+        if cap < 1:
+            continue
+        try:
+            source = Image.open(path)
+        except Exception as exc:
+            logger.warning("图片解码失败，回退为文档发送: %s", exc)
+            return None
+        try:
+            if str(source.format or "").upper() in DRAFT_DECODE_FORMATS:
+                # Reduced-scale JPEG decode: throw away DCT blocks first so the
+                # peak working set follows the cap instead of the source size.
+                # Over budget we ask for half the cap, which forces the decoder
+                # into a power-of-two reduction instead of a full-size decode.
+                draft_cap = cap
+                if estimate_resources(probe).estimated_peak_bytes > limits.decode_budget_bytes:
+                    draft_cap = max(1, cap // 2)
+                source.draft("RGB", (draft_cap, draft_cap))
+            converted = None
+            resized = None
+            try:
+                image = source
+                # Shrink before RGB conversion so RGBA does not create a second
+                # full-size pixel buffer at the source resolution.
+                if max(image.size) > cap:
+                    resized = image.resize(
+                        _scaled_size(image.size, cap), Image.Resampling.LANCZOS
+                    )
+                    image = resized
+                if image.mode not in ("RGB", "L"):
+                    converted = image.convert("RGB")
+                    image = converted
+                for quality in JPEG_QUALITIES:
+                    derivative = _save_jpeg(image, directory, quality)
+                    if derivative is None:
+                        continue
+                    if _artifact_is_compliant(derivative, limits):
+                        return derivative
+                    _unlink(derivative)
+            finally:
+                for buffer in (resized, converted):
+                    if buffer is not None:
+                        buffer.close()
+        finally:
+            source.close()
     return None
+
+
+def retry_photo_derivative(path: str, *,
+                           max_bytes: int = PHOTO_MAX_BYTES,
+                           limits: Optional[PhotoLimits] = None) -> Optional[str]:
+    """ONE bounded, more aggressive re-process for a photo Telegram rejected.
+
+    Halves the long edge (still dimension-sum compliant) and walks the quality
+    ladder from the top; returns a compliant derivative, or ``None``. The caller
+    must try this at most once, then fall back to a document.
+    """
+    limits = limits or PhotoLimits(max_bytes=max_bytes)
+    try:
+        probe = probe_image(path)
+    except Exception:
+        return None
+    longest = max(probe.width, probe.height)
+    cap = max(1, longest // 2)
+    if probe.width + probe.height > limits.max_dimension_sum:
+        allowed = (limits.max_dimension_sum * longest) // (probe.width + probe.height)
+        cap = min(cap, max(1, allowed))
+    cap = min(cap, limits.max_edge)
+    return compress_photo(
+        path, limits.max_bytes, probe=probe, limits=limits, dimension_caps=[cap]
+    )
+
+
+def _prepare_many(entries: Sequence[Tuple[str, Optional[str]]],
+                  policy: MediaPreparationPolicy) -> List[PreparedMedia]:
+    """Prepare images one at a time (bounded concurrency), never a whole gallery."""
+    if len(entries) > 1 and MEDIA_PREPARE_CONCURRENCY > 1:
+        with ThreadPoolExecutor(max_workers=MEDIA_PREPARE_CONCURRENCY) as pool:
+            return list(pool.map(
+                lambda entry: policy.prepare(entry[0], preview_path=entry[1]),
+                entries,
+            ))
+    return [
+        policy.prepare(path, preview_path=preview) for path, preview in entries
+    ]
 
 
 def cleanup_prepared(items: List[MediaItem]) -> None:
     for item in items:
         source = item.source
         if isinstance(source, LocalFile) and source.temporary:
-            try:
-                os.unlink(source.path)
-            except OSError:
-                pass
+            _unlink(source.path)
 
 
 def cleanup_prepared_dicts(items: list) -> None:
     for item in items:
         if item.get("temporary"):
-            try:
-                os.unlink(item["path"])
-            except OSError:
-                pass
+            _unlink(item["path"])
 
 
 def reclassify_oversized_dicts(items: list, *,
@@ -321,14 +674,17 @@ def reclassify_oversized_dicts(items: list, *,
     payloads (one per classified photo) for the durable media.prepared audit.
     """
     policy = MediaPreparationPolicy(max_bytes=max_bytes)
+    entries = [
+        (item["path"], item.get("preview_path") if use_preview else None)
+        for item in items
+        if item.get("kind") == "photo" and item.get("path")
+    ]
+    prepared_list = iter(_prepare_many(entries, policy))
     out: list = []
     decisions: list = []
     for item in items:
         if item.get("kind") == "photo" and item.get("path"):
-            prepared = policy.prepare(
-                item["path"],
-                preview_path=item.get("preview_path") if use_preview else None,
-            )
+            prepared = next(prepared_list)
             item = dict(item)
             item["path"] = prepared.delivery_source
             item["kind"] = prepared.kind.value
@@ -353,38 +709,46 @@ def reclassify_oversized(items: List[MediaItem], *,
                          max_bytes: int = PHOTO_MAX_BYTES) -> List[MediaItem]:
     """Return canonical prepared items without modifying original artifacts."""
     policy = MediaPreparationPolicy(max_bytes=max_bytes)
+    photo_indexes = [
+        index for index, item in enumerate(items)
+        if item.kind is MediaKind.PHOTO and isinstance(item.source, LocalFile)
+    ]
+    prepared_by_index: Dict[int, PreparedMedia] = {}
+    if photo_indexes:
+        prepared = _prepare_many(
+            [(items[index].source.path, None) for index in photo_indexes], policy
+        )
+        prepared_by_index = dict(zip(photo_indexes, prepared))
+
     out: List[MediaItem] = []
-    for item in items:
-        if item.kind is MediaKind.PHOTO:
+    for index, item in enumerate(items):
+        prepared = prepared_by_index.get(index)
+        if prepared is not None:
             source = item.source
-            if isinstance(source, LocalFile):
-                prepared = policy.prepare(
-                    source.path
+            filename = source.filename
+            if prepared.reason is PreparationDecision.SAFE_COMPRESS:
+                filename = f"{os.path.splitext(filename)[0]}.jpg"
+            item = MediaItem(
+                prepared.kind,
+                LocalFile(
+                    prepared.delivery_source,
+                    filename,
+                    preview_path=source.preview_path,
+                    original_path=prepared.original_source,
+                    temporary=prepared.temporary,
+                ),
+                item.spoiler if prepared.kind is MediaKind.PHOTO else False,
+            )
+            if prepared.decision is not None:
+                payload = dict(prepared.decision)
+                if filename:
+                    payload["filename"] = filename
+                log_media_decision(payload)
+            else:
+                logger.info(
+                    "图片准备决策=%s source=%s delivery=%s",
+                    prepared.reason.value, prepared.original_source,
+                    prepared.delivery_source,
                 )
-                filename = source.filename
-                if prepared.reason is PreparationDecision.SAFE_COMPRESS:
-                    filename = f"{os.path.splitext(filename)[0]}.jpg"
-                item = MediaItem(
-                    prepared.kind,
-                    LocalFile(
-                        prepared.delivery_source,
-                        filename,
-                        preview_path=source.preview_path,
-                        original_path=prepared.original_source,
-                        temporary=prepared.temporary,
-                    ),
-                    item.spoiler if prepared.kind is MediaKind.PHOTO else False,
-                )
-                if prepared.decision is not None:
-                    payload = dict(prepared.decision)
-                    if filename:
-                        payload["filename"] = filename
-                    log_media_decision(payload)
-                else:
-                    logger.info(
-                        "图片准备决策=%s source=%s delivery=%s",
-                        prepared.reason.value, prepared.original_source,
-                        prepared.delivery_source,
-                    )
         out.append(item)
     return out

--- a/telepost/telegram/review_stager.py
+++ b/telepost/telegram/review_stager.py
@@ -28,7 +28,9 @@ from ..application.review_queue import pixiv_id_from_link
 from .delivery.preparation import (
     PHOTO_MAX_BYTES,
     cleanup_prepared_dicts,
+    is_photo_constraint_error,
     reclassify_oversized_dicts as reclassify_oversized,
+    retry_photo_derivative,
 )
 from .delivery.sender import file_id_of, timeout_kwargs
 from . import review_keyboard
@@ -344,22 +346,102 @@ class TelegramReviewStager:
                         logger.debug("关闭预览文件句柄失败", exc_info=True)
         return await self._send_throttled(factory)
 
+    def _photo_send(self, path, filename, caption, spoiler, common):
+        async def factory():
+            handle = open(path, "rb")
+            try:
+                media = InputFile(handle, filename=filename,
+                                  read_file_handle=False, attach=True)
+                return await self._bot.send_photo(
+                    photo=media, caption=caption,
+                    parse_mode="HTML" if caption else None,
+                    has_spoiler=spoiler, **common)
+            finally:
+                handle.close()
+        return factory
+
+    def _document_send(self, path, filename, caption, common):
+        async def factory():
+            handle = open(path, "rb")
+            try:
+                media = InputFile(handle, filename=filename,
+                                  read_file_handle=False, attach=True)
+                return await self._bot.send_document(
+                    document=media, filename=filename, caption=caption,
+                    parse_mode="HTML" if caption else None, **common)
+            finally:
+                handle.close()
+        return factory
+
+    async def _local_photo_single(self, item, caption, spoiler, reply_to):
+        """Send one local photo; Telegram's verdict, not ours, is the last word.
+
+        On a photo-constraint rejection (dimensions / ratio / size) the artifact
+        gets exactly ONE bounded re-process and is retried as a photo; only if
+        that also fails does it go out as a document.
+        """
+        common = {"chat_id": self.chat_id, **self._timeouts_now()}
+        if reply_to is not None:
+            common["reply_to_message_id"] = reply_to
+        path = item["path"]
+        filename = item.get("filename") or "file"
+        try:
+            return await self._send_throttled(
+                self._photo_send(path, filename, caption, spoiler, common)
+            )
+        except Exception as exc:
+            if not is_photo_constraint_error(exc):
+                raise
+            logger.warning(
+                "审核预览照片被 Telegram 拒绝（%s），执行一次上限内的重新压缩: %s",
+                exc, filename,
+            )
+
+        derivative = retry_photo_derivative(path, max_bytes=self._photo_max_bytes)
+        if derivative:
+            try:
+                return await self._send_throttled(
+                    self._photo_send(
+                        derivative, f"{os.path.splitext(filename)[0]}.jpg",
+                        caption, spoiler, common,
+                    )
+                )
+            except Exception as retry_exc:
+                if not is_photo_constraint_error(retry_exc):
+                    raise
+                logger.warning(
+                    "审核预览照片二次压缩后仍被拒绝（%s），改按文档发送: %s",
+                    retry_exc, filename,
+                )
+            finally:
+                try:
+                    os.remove(derivative)
+                except OSError:
+                    pass
+
+        # No bounded photo attempt is left: a document is the only legal target.
+        # ``_stage`` reads item["kind"] after the send, so this item is staged
+        # (and later published) as a document too.
+        item["kind"] = "document"
+        item["preparation_reason"] = "photo_constraint_document_fallback"
+        return await self._send_throttled(
+            self._document_send(path, filename, caption, common)
+        )
+
     async def _local_single(self, item, caption, spoiler, reply_to):
         common = {"chat_id": self.chat_id, **self._timeouts_now()}
         if reply_to is not None:
             common["reply_to_message_id"] = reply_to
         kind = item["kind"]
 
+        if kind == "photo":
+            return await self._local_photo_single(item, caption, spoiler, reply_to)
+
         async def factory():
             handle = open(item["path"], "rb")
             try:
                 media = InputFile(handle, filename=item["filename"],
                                   read_file_handle=False, attach=True)
-                if kind == "photo":
-                    return await self._bot.send_photo(
-                        photo=media, caption=caption,
-                        parse_mode="HTML" if caption else None,
-                        has_spoiler=spoiler, **common)
                 if kind == "video":
                     return await self._bot.send_video(
                         video=media, caption=caption,

--- a/tests/test_architecture_core.py
+++ b/tests/test_architecture_core.py
@@ -122,8 +122,14 @@ def test_documents_form_their_own_albums():
 
 def test_family_order_puts_visuals_first():
     items = [_fid("document", 1), _fid("photo", 1)]
-    plan = plan_delivery(items)
+    plan = plan_delivery(items, ordering=PlanningOrder.FAMILY)
     assert plan.batches[0].family == "visual"
+
+
+def test_default_ordering_keeps_the_artwork_order():
+    items = [_fid("document", 1), _fid("photo", 1), _fid("photo", 2)]
+    plan = plan_delivery(items)
+    assert [b.family for b in plan.batches] == ["document", "visual"]
 
 
 def test_input_ordering_preserves_upload_order_runs():

--- a/tests/test_media_delivery_pipeline.py
+++ b/tests/test_media_delivery_pipeline.py
@@ -1,0 +1,491 @@
+"""Regression tests: media classification + album planning.
+
+Production bug: a Pixiv multi-image gallery reached the review group as a photo
+album followed by a separate batch of *documents*, including files well under
+10 MB that could and should have been photos.
+
+Root cause (``telepost/telegram/delivery/preparation.py``): every violation that
+could have been fixed by producing a smaller photo — a width+height sum over
+Telegram's 10000 limit, an over-budget decode, a byte cap the quality ladder
+could not reach — was answered with ``MediaKind.DOCUMENT`` instead. The planner
+then grouped those documents into their own album.
+
+The classification decision is now always taken on the FINAL artifact, and a
+photo is only abandoned when no compliant photo artifact is reachable.
+
+Telegram constraints asserted here come from https://core.telegram.org/bots/api
+(sendPhoto: "at most 10 MB in size", "width and height must not exceed 10000 in
+total", "Width and height ratio must be at most 20"; sendMediaGroup: "2-10
+items"; sendAnimation/sendDocument: "up to 50 MB").
+"""
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from PIL import Image
+
+from telepost.domain.delivery import DeliveredMessage, LocalFile, MediaItem, MediaKind
+from telepost.telegram.delivery import preparation
+from telepost.telegram.delivery.planner import BatchKind, plan_delivery
+
+PHOTO_LIMIT = preparation.PHOTO_MAX_BYTES
+
+
+# --------------------------------------------------------------------------
+# fixtures built at test time (no binaries in the repo)
+# --------------------------------------------------------------------------
+
+def _noise_jpeg(path, size, quality=95):
+    """A JPEG whose byte size is driven by real image entropy."""
+    image = Image.frombytes("RGB", size, os.urandom(size[0] * size[1] * 3))
+    image.save(path, "JPEG", quality=quality)
+    return path
+
+
+def _flat_jpeg(path, size, quality=70):
+    """Compressible high-resolution JPEG: big pixels, small file."""
+    Image.linear_gradient("L").resize(size).convert("RGB").save(
+        path, "JPEG", quality=quality
+    )
+    return path
+
+
+def _animated(path, frames=4, fmt="GIF"):
+    images = [Image.new("RGB", (64, 64), (i * 40 % 255, 20, 30))
+              for i in range(frames)]
+    images[0].save(path, format=fmt, save_all=True, append_images=images[1:],
+                   duration=100, loop=0)
+    return path
+
+
+def _gallery(tmp_path):
+    """small / large / small / large in *source* order."""
+    return [
+        _flat_jpeg(tmp_path / "g0.jpg", (900, 700)),
+        _noise_jpeg(tmp_path / "g1.jpg", (3000, 3000)),
+        _flat_jpeg(tmp_path / "g2.jpg", (800, 600)),
+        _noise_jpeg(tmp_path / "g3.jpg", (3000, 3000)),
+    ]
+
+
+def _flatten(plan):
+    return [
+        item.filename or item.telegram_file_id
+        for batch in plan.batches for item in batch.items
+    ]
+
+
+def _fake_message(index):
+    return SimpleNamespace(
+        message_id=index + 1,
+        chat=SimpleNamespace(id=-100123),
+        photo=[SimpleNamespace(file_id=f"F{index}")],
+    )
+
+
+# --------------------------------------------------------------------------
+# 1-4: single-image classification
+# --------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_single_ordinary_jpeg_is_a_photo(tmp_path):
+    path = _flat_jpeg(tmp_path / "ordinary.jpg", (800, 600))
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.PHOTO
+    assert result.reason is preparation.PreparationDecision.PASS_THROUGH
+    assert result.delivery_source == str(path)
+    assert result.decision["violation"] is None
+
+
+@pytest.mark.unit
+def test_nine_megabyte_jpeg_passes_through_untouched(tmp_path):
+    path = _noise_jpeg(tmp_path / "nine.jpg", (2800, 2800), quality=95)
+    assert PHOTO_LIMIT - 1_000_000 < path.stat().st_size <= PHOTO_LIMIT
+
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.PHOTO
+    assert result.reason is preparation.PreparationDecision.PASS_THROUGH
+    assert result.delivery_source == str(path), "a legal photo must not be re-encoded"
+    assert result.decision["decision"] == "photo_passthrough"
+    assert result.decision["reason"] == "already_within_limits"
+
+
+@pytest.mark.unit
+def test_fifteen_megabyte_jpeg_is_compressed_and_stays_a_photo(tmp_path):
+    """The old ladder could only lower quality; the target kind must stay photo."""
+    path = _noise_jpeg(tmp_path / "fifteen.jpg", (3500, 3500), quality=95)
+    assert path.stat().st_size > 10 * 1024 * 1024
+
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.PHOTO, "an oversized JPEG must not become a document"
+    assert result.reason is preparation.PreparationDecision.SAFE_COMPRESS
+    assert result.decision["violation"] == "photo_bytes_exceeded"
+
+    final = result.decision
+    assert final["final_bytes"] <= PHOTO_LIMIT
+    assert final["final_width"] + final["final_height"] <= 10000
+    assert final["final_format"] == "JPEG"
+    assert result.delivery_source != str(path)
+    assert path.stat().st_size > 10 * 1024 * 1024, "the original stays immutable"
+
+
+@pytest.mark.unit
+def test_high_resolution_small_bytes_jpeg_is_downscaled_to_a_photo(tmp_path):
+    """Primary regression: 6000x5000 / ~0.5 MB used to be sent as a document.
+
+    width + height = 11000 > 10000, so Telegram refuses it as a photo — but a
+    downscale produces a legal photo, which is always the preferred target.
+    """
+    path = _flat_jpeg(tmp_path / "huge-small.jpg", (6000, 5000))
+    assert path.stat().st_size < PHOTO_LIMIT, "the byte cap is not the problem here"
+
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.PHOTO, "dimension violation must downscale, not demote"
+    assert result.reason is preparation.PreparationDecision.SAFE_COMPRESS
+
+    payload = result.decision
+    assert payload["violation"] == "photo_dimensions_exceeded"
+    assert payload["resized"] is True
+    assert payload["final_width"] + payload["final_height"] <= 10000
+    assert payload["final_bytes"] <= PHOTO_LIMIT
+    assert payload["final_format"] == "JPEG"
+    # the audit line must reconstruct the whole decision
+    assert {
+        "original_bytes", "final_bytes", "final_width", "final_height",
+        "final_format", "original_format", "target_kind", "decision",
+        "fallback_reason", "violation",
+    } <= set(payload)
+    assert payload["original_format"] == "JPEG"
+    assert payload["target_kind"] == "photo"
+
+
+@pytest.mark.unit
+def test_decode_budget_routes_to_a_reduced_decode_instead_of_document(tmp_path):
+    """The budget is a routing decision: JPEG can decode at a reduced scale."""
+    path = _flat_jpeg(tmp_path / "budget.jpg", (6000, 5000))
+    policy = preparation.MediaPreparationPolicy(
+        limits=preparation.PhotoLimits(max_bytes=PHOTO_LIMIT, decode_budget_bytes=1)
+    )
+    result = policy.prepare(str(path))
+    assert result.kind is MediaKind.PHOTO
+    # Image.draft() dropped DCT blocks before allocating pixels.
+    assert result.decision["final_width"] <= 3000
+
+
+@pytest.mark.unit
+def test_impossible_case_records_an_explicit_document_fallback_reason(tmp_path):
+    """A PNG has no reduced-scale decode in Pillow: over the budget *and* over
+    the dimension rule, no compliant photo exists — and the log says exactly why."""
+    path = tmp_path / "huge.png"
+    Image.new("RGBA", (6000, 5000), (10, 20, 30, 255)).save(path)
+    assert path.stat().st_size < PHOTO_LIMIT
+
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.DOCUMENT
+    assert result.reason is preparation.PreparationDecision.DOCUMENT_FALLBACK
+    assert result.delivery_source == str(path)
+    payload = result.decision
+    assert payload["violation"] == "photo_dimensions_exceeded"
+    assert payload["fallback_reason"] == "decode_budget_exceeded"
+    assert payload["target_kind"] == "document"
+
+
+# --------------------------------------------------------------------------
+# 5-7: album planning
+# --------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_gallery_of_interleaved_sizes_plans_photo_albums_in_source_order(tmp_path):
+    paths = _gallery(tmp_path)
+    source_order = [path.name for path in paths]
+    items = [
+        MediaItem.local("photo", str(path), path.name) for path in paths
+    ]
+
+    prepared = preparation.reclassify_oversized(items)
+    assert all(item.kind is MediaKind.PHOTO for item in prepared), \
+        "no item of this gallery needs to be a document"
+
+    plan = plan_delivery(prepared, album_size=10)
+    assert len(plan.batches) == 1
+    assert plan.batches[0].kind is BatchKind.ALBUM
+    assert [batch.family for batch in plan.batches] == ["visual"]
+    assert _flatten(plan) == source_order, "artwork order must survive preparation"
+
+
+@pytest.mark.unit
+def test_ten_items_make_one_album():
+    plan = plan_delivery(
+        [MediaItem.file_id("photo", f"p{i}") for i in range(10)]
+    )
+    assert len(plan.batches) == 1
+    assert plan.batches[0].is_album
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("count", [11, 23])
+def test_more_than_ten_items_split_into_albums_keeping_order(count):
+    items = [MediaItem.file_id("photo", f"p{i}") for i in range(count)]
+    plan = plan_delivery(items, album_size=10)
+    assert [len(batch.items) for batch in plan.batches] == (
+        [10] * (count // 10) + ([count % 10] if count % 10 else [])
+    )
+    assert _flatten(plan) == [f"p{i}" for i in range(count)]
+
+
+@pytest.mark.unit
+def test_mixed_gallery_keeps_order_and_adds_no_document_split(tmp_path):
+    """A gallery that can be made fully compliant must never split photo/document."""
+    paths = _gallery(tmp_path)
+    animated = _animated(tmp_path / "loop.gif")
+    items = [MediaItem.local("photo", str(path), path.name) for path in paths]
+    # an animation that arrived misclassified as a photo
+    items.insert(2, MediaItem.local("photo", str(animated), "loop.gif"))
+
+    prepared = preparation.reclassify_oversized(items)
+    plan = plan_delivery(prepared, album_size=10)
+
+    assert _flatten(plan) == ["g0.jpg", "g1.jpg", "loop.gif", "g2.jpg", "g3.jpg"]
+    assert {batch.family for batch in plan.batches} == {"visual", "animation"}
+    assert all(
+        item.kind is not MediaKind.DOCUMENT
+        for batch in plan.batches for item in batch.items
+    )
+    families = [batch.family for batch in plan.batches]
+    assert families.count("animation") == 1, "the animation stays standalone"
+
+
+# --------------------------------------------------------------------------
+# 8: animations are never staticized
+# --------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("fmt,suffix", [("GIF", ".gif"), ("WEBP", ".webp"),
+                                        ("PNG", ".png")])
+def test_animated_images_are_never_staticized(tmp_path, fmt, suffix):
+    path = _animated(tmp_path / f"loop{suffix}", fmt=fmt)
+    pytest.importorskip("PIL")
+    if Image.open(path).n_frames < 2:  # pragma: no cover - Pillow build without support
+        pytest.skip(f"{fmt} animation not supported by this Pillow build")
+
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.ANIMATION
+    assert result.reason is preparation.PreparationDecision.ANIMATION_PRESERVED
+    assert result.delivery_source == str(path), "the animation must not be re-encoded"
+    assert result.decision["target_kind"] == "animation"
+    assert result.decision["reason"] == "animated_never_static"
+
+
+@pytest.mark.unit
+def test_animation_arriving_as_photo_is_reclassified_and_explained(tmp_path):
+    """An animated item tagged 'photo' must not silently become a static photo."""
+    path = _animated(tmp_path / "loop.gif")
+    items, decisions = preparation.reclassify_oversized_dicts(
+        [{"kind": "photo", "path": str(path), "filename": "loop.gif"}]
+    )
+    assert items[0]["kind"] == "animation"
+    assert items[0]["preparation_reason"] == "animation_preserved"
+    assert decisions[0]["reason"] == "animated_never_static"
+
+
+@pytest.mark.unit
+def test_animation_over_the_animation_byte_limit_becomes_a_document(tmp_path, monkeypatch):
+    path = _animated(tmp_path / "loop.gif")
+    monkeypatch.setattr(preparation, "MEDIA_MAX_BYTES", 1)
+    result = preparation.MediaPreparationPolicy().prepare(str(path))
+    assert result.kind is MediaKind.DOCUMENT
+    assert result.decision["reason"] == "animation_exceeds_animation_byte_limit"
+
+
+# --------------------------------------------------------------------------
+# 9: bounded photo retry on a real Telegram rejection
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_photo_rejected_by_telegram_is_reprocessed_once_then_sent(tmp_path):
+    from telegram.error import BadRequest
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    path = _flat_jpeg(tmp_path / "photo.jpg", (4000, 3000))
+    sent_paths = []
+    bot = AsyncMock()
+
+    async def send_photo(**kwargs):
+        sent_paths.append(kwargs["photo"].input_file_content.name)
+        if len(sent_paths) == 1:
+            raise BadRequest("Photo_invalid_dimensions")
+        return _fake_message(0)
+
+    bot.send_photo = AsyncMock(side_effect=send_photo)
+    stager = TelegramReviewStager(bot, -100123, sleep=AsyncMock())
+    item = {"kind": "photo", "path": str(path), "filename": "photo.jpg"}
+
+    message = await stager._local_single(item, None, False, None)
+
+    assert message.message_id == 1
+    assert len(sent_paths) == 2, "exactly ONE bounded re-process attempt"
+    assert sent_paths[0] == str(path)
+    assert sent_paths[1] != str(path), "the retry must use a fresh derivative"
+    assert item["kind"] == "photo", "the retry stays a photo"
+    bot.send_document.assert_not_awaited()
+
+
+class _RejectingPhotoSender:
+    """Fake transport for the executor: rejects N photo sends, then succeeds."""
+
+    def __init__(self, rejections=1, error="Bad Request: PHOTO_INVALID_DIMENSIONS"):
+        self.rejections = rejections
+        self.error = error
+        self.calls = []
+
+    async def send_album(self, batch, *, reply_to, caption):
+        raise AssertionError("this test never plans an album")
+
+    async def send_single(self, item, *, reply_to, caption):
+        self.calls.append((item.kind, item.local_path, item.filename))
+        if item.kind is MediaKind.PHOTO and self.rejections > 0:
+            self.rejections -= 1
+            raise RuntimeError(self.error)
+        return DeliveredMessage(chat_id=-100, message_id=len(self.calls),
+                                kind=item.kind)
+
+
+@pytest.mark.asyncio
+async def test_executor_reprocesses_a_telegram_rejected_photo_once(tmp_path):
+    from telepost.telegram.delivery.executor import execute_plan
+
+    path = _flat_jpeg(tmp_path / "channel.jpg", (4000, 3000))
+    item = MediaItem.local("photo", str(path), "channel.jpg")
+    sender = _RejectingPhotoSender(rejections=1)
+
+    result = await execute_plan(plan_delivery([item]), sender)
+
+    assert result.ok, result.reason
+    assert len(sender.calls) == 2, "exactly one retry"
+    assert sender.calls[0][0] is MediaKind.PHOTO
+    assert sender.calls[0][1] == str(path)
+    assert sender.calls[1][0] is MediaKind.PHOTO, "the retry is still a photo"
+    assert sender.calls[1][1] != str(path)
+    assert not os.path.exists(sender.calls[1][1]), "the derivative is cleaned up"
+    assert path.exists()
+
+
+@pytest.mark.asyncio
+async def test_executor_falls_back_to_document_only_after_the_retry(tmp_path):
+    from telepost.telegram.delivery.executor import execute_plan
+
+    path = _flat_jpeg(tmp_path / "channel.jpg", (4000, 3000))
+    item = MediaItem.local("photo", str(path), "channel.jpg")
+    sender = _RejectingPhotoSender(rejections=99)
+
+    result = await execute_plan(plan_delivery([item]), sender)
+
+    assert result.ok, "the artwork must still ship, as a document"
+    assert [call[0] for call in sender.calls] == [
+        MediaKind.PHOTO, MediaKind.PHOTO, MediaKind.DOCUMENT,
+    ]
+    assert sender.calls[2][1] == str(path), "the document is the original"
+
+
+@pytest.mark.asyncio
+async def test_executor_does_not_retry_unrelated_photo_errors(tmp_path):
+    from telepost.telegram.delivery.executor import execute_plan
+
+    path = _flat_jpeg(tmp_path / "channel.jpg", (4000, 3000))
+    item = MediaItem.local("photo", str(path), "channel.jpg")
+    sender = _RejectingPhotoSender(rejections=99, error="Bad Request: chat not found")
+
+    result = await execute_plan(plan_delivery([item]), sender)
+
+    assert not result.ok
+    assert len(sender.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_photo_rejected_twice_falls_back_to_document(tmp_path):
+    from telegram.error import BadRequest
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    path = _flat_jpeg(tmp_path / "photo.jpg", (4000, 3000))
+    bot = AsyncMock()
+    bot.send_photo = AsyncMock(side_effect=BadRequest("Photo_invalid_dimensions"))
+    bot.send_document = AsyncMock(return_value=_fake_message(0))
+    stager = TelegramReviewStager(bot, -100123, sleep=AsyncMock())
+    item = {"kind": "photo", "path": str(path), "filename": "photo.jpg"}
+
+    message = await stager._local_single(item, None, False, None)
+
+    assert bot.send_photo.await_count == 2, "no unbounded retry loop"
+    assert bot.send_document.await_count == 1
+    assert item["kind"] == "document"
+    assert item["preparation_reason"] == "photo_constraint_document_fallback"
+    assert message.message_id == 1
+
+
+@pytest.mark.asyncio
+async def test_unrelated_photo_errors_are_not_retried(tmp_path):
+    from telegram.error import BadRequest
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    path = _flat_jpeg(tmp_path / "photo.jpg", (4000, 3000))
+    bot = AsyncMock()
+    bot.send_photo = AsyncMock(side_effect=BadRequest("Chat not found"))
+    stager = TelegramReviewStager(bot, -100123, sleep=AsyncMock())
+
+    with pytest.raises(BadRequest):
+        await stager._local_single(
+            {"kind": "photo", "path": str(path), "filename": "photo.jpg"},
+            None, False, None,
+        )
+    assert bot.send_photo.await_count == 1
+
+
+# --------------------------------------------------------------------------
+# 11: the review group sees one ordered photo album (end to end)
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_review_group_gallery_is_one_photo_album_in_source_order(tmp_path):
+    from telepost.telegram.review_stager import TelegramReviewStager
+
+    paths = _gallery(tmp_path)
+    files = [{"kind": "photo", "path": str(path), "filename": path.name}
+             for path in paths]
+    bot = AsyncMock()
+
+    async def send_media_group(**kwargs):
+        return [_fake_message(i) for i in range(len(kwargs["media"]))]
+
+    bot.send_media_group = AsyncMock(side_effect=send_media_group)
+    stager = TelegramReviewStager(bot, -100123, sleep=AsyncMock())
+
+    media, documents, _ids, _decisions = await stager.stage_local(
+        files, caption="caption", spoiler=False
+    )
+
+    assert bot.send_media_group.await_count == 1
+    assert bot.send_document.await_count == 0
+    assert bot.send_photo.await_count == 0
+    assert len(bot.send_media_group.call_args.kwargs["media"]) == 4
+    assert documents == []
+    assert [m["type"] for m in media] == ["photo"] * 4
+    assert [m["file_id"] for m in media] == ["F0", "F1", "F2", "F3"]
+
+
+@pytest.mark.unit
+def test_prepared_derivatives_are_temp_files_that_can_be_cleaned(tmp_path):
+    """Memory hygiene: one derivative per transformed image, removed by cleanup."""
+    path = _noise_jpeg(tmp_path / "fifteen.jpg", (3500, 3500), quality=95)
+    item = MediaItem.local("photo", str(path), "fifteen.jpg")
+    prepared = preparation.reclassify_oversized([item])[0]
+    derivative = prepared.source.path
+
+    assert isinstance(prepared.source, LocalFile)
+    assert prepared.source.temporary is True
+    assert prepared.source.original_path == str(path)
+    assert os.path.exists(derivative)
+
+    preparation.cleanup_prepared([prepared])
+    assert not os.path.exists(derivative)
+    assert path.exists()

--- a/tests/test_media_preparation.py
+++ b/tests/test_media_preparation.py
@@ -55,8 +55,14 @@ def test_huge_rgba_never_enters_full_decode(tmp_path, monkeypatch):
 
 @pytest.mark.unit
 def test_small_file_with_oversized_dimensions_falls_back_to_document(tmp_path, monkeypatch):
-    """Telegram rejects such photos with Photo_invalid_dimensions even though
-    the file is tiny; the original must go out as a document instead."""
+    """A 5-byte PNG stub cannot be decoded, so no compliant photo exists.
+
+    The primary violation is still reported (this used to be a blanket
+    document fallback for *every* oversized-dimension image — see
+    ``test_high_resolution_small_bytes_jpeg_is_downscaled_to_a_photo`` in
+    ``test_media_delivery_pipeline.py`` for the real fix), but
+    the fallback reason is now explicit: the decode budget, not the dimensions.
+    """
     source = tmp_path / "wide.png"
     source.write_bytes(b"small")
 
@@ -82,7 +88,8 @@ def test_small_file_with_oversized_dimensions_falls_back_to_document(tmp_path, m
     assert result.reason is preparation.PreparationDecision.DOCUMENT_FALLBACK
     assert result.kind is MediaKind.DOCUMENT
     assert result.delivery_source == str(source)
-    assert result.decision["reason"] == "photo_dimensions_too_large"
+    assert result.decision["violation"] == "photo_dimensions_exceeded"
+    assert result.decision["fallback_reason"] == "decode_budget_exceeded"
 
 
 @pytest.mark.unit
@@ -199,7 +206,7 @@ def test_compression_failure_uses_preview_then_document(tmp_path, monkeypatch):
         source.stat().st_size, "PNG", 100, 100, "RGBA", 1
     )
     monkeypatch.setattr(preparation, "probe_image", lambda _path: probe)
-    monkeypatch.setattr(preparation, "compress_photo", lambda *_a: None)
+    monkeypatch.setattr(preparation, "compress_photo", lambda *_a, **_kw: None)
 
     policy = preparation.MediaPreparationPolicy()
     assert policy.prepare(


### PR DESCRIPTION
## 症状

Pixiv 多图作品投到审核群后，一部分图片以**相册**到达，另一部分以**document**到达，
排版割裂。最不合逻辑的是：被当 document 发出的那些文件里，**有些本身远小于 10 MB**，
完全够格作为 Telegram photo 发送。

## 根因（已定位到行）

`telepost/telegram/delivery/preparation.py` 的 `MediaPreparationPolicy.prepare()`：

1. **尺寸违规被直接降级成 document，而不是缩放。** 文件 `<= max_bytes` 时检查
   `width + height > 10000`，命中就 `_fallback(reason="photo_dimensions_too_large")`
   → `MediaKind.DOCUMENT`。一张 6000x5000、只有几百 KB 的 JPEG 因此**永久**变成
   document —— 这正是「< 10 MB 却被当 document 发出」的主因：一个缩放就能让它合法。
2. **解码预算被当成降级理由，而不是路由决策。** `frames > 1 or estimated_peak_bytes >
   decode_budget` 直接 → DOCUMENT。
3. **`compress_photo()` 没有尺寸阶梯。** 只在原尺寸上试 JPEG quality 85/70/55
   （仅在 `max(size) > 4096` 时硬 thumbnail 到 4096）；q55 仍超限就失败 → document。
4. **最终产物从未被整体复验。** 只检查 `os.stat().st_size`，产物的宽高与格式都没验。
5. **`_fallback` 依据 source 属性决定 kind** —— 就是「source metadata 与 final artifact
   metadata 混用」这个反模式。

`planner.py` 的 FAMILY 排序把 photo 排在 document 前面，正好把上述误分类放大成
「先一组图片、再一组 document」。

## 新管线

```text
probe（仅读文件头：Image.open/.size，不 decode 像素）
  -> 依 probe + source metadata 判定目标类型
  -> 仅在必要时变换：quality 85/75/65/55 -> 由 10000 之和推导的尺寸上限 -> JPEG 归一化
  -> **复验最终产物**：bytes、width+height<=10000、长宽比<=20、格式
  -> 依最终产物**重新分类** -> PreparedMedia(reason, violation, fallback_reason)
```

- 静态图首选永远是 photo；只有确实做不出合规 photo 时才降级 document。
- `MediaArtifact.photo_violation()` 是唯一的合规定义，分类与校验共用同一处判断。
- 内存：逐张处理（`TELEPOST_MEDIA_PREPARE_CONCURRENCY` 默认 1），超预算时走
  `Image.draft()` 降采样解码；buffer 在 `finally` 关闭。
- `MediaPreparationPolicy` 保留 `reclassify_oversized` / `reclassify_oversized_dicts` /
  `cleanup_prepared` 等原有公开函数签名，调用方无需改动。

**约束来自官方文档，不是猜的**（[sendPhoto](https://core.telegram.org/bots/api#sendphoto)）：
*"at most 10 MB in size"*、*"width and height must not exceed 10000 in total"*、
*"Width and height ratio must be at most 20"*；[Sending Files](https://core.telegram.org/bots/api#sending-files)：
*"10 MB max size for photos, 50 MB for other files"*，`sendMediaGroup` 走同一条
InputMediaPhoto 上传路径且 *"must include 2-10 items"*。原先硬编码的 10000 是对的，
**长宽比 <= 20 原先完全没校验**，现在补上。

## 有界重试

`sendPhoto` 因 Telegram 真实约束被拒时，只对该 artifact 重做**一次**有界重压缩/缩放
再试 photo，仍失败才降级 document。只在观测到真实 Telegram 错误时触发；其他错误照常
上抛；重试后网络中断返回 UNCERTAIN，绝不静默重发。

## 顺序与分批

`planner` 默认改为 INPUT 顺序：只在 Telegram 强制要求时才按 family 拆分
（animation/audio 不能进 media group，document 必须同质）。正常相册因此是**按原作品
顺序的照片组**，每组 <= 10。顺带把 `FAMILY_ORDER` 里 str/MediaKind 混用键改成纯字符串键
（实测 CPython 3.12/3.14 下能用，但属于易碎的隐式行为）。

## 测试

| 命令 | 结果 |
| --- | --- |
| `.venv/bin/python -m pytest -q` | **609 passed, 1 skipped** |
| 改动前基线 | 584 passed, 1 skipped |
| `make -f Makefile.tests test` | 609 passed, 1 skipped |
| `pytest -m unit` / `-m integration` | 324 passed / 11 passed, 1 skipped |

新增 `tests/test_media_delivery_pipeline.py`（24 个）：普通 JPEG→photo；
~9 MB 原样透传不重编码；~15 MB → 压缩后 **final target 仍是 photo**；
6000x5000 小体积 → 缩放后是 photo（主回归）；交错大小相册 → 单一有序照片相册；
10 / 11 / 23 张分批且顺序不变；动图 GIF/WebP/APNG **绝不**被静态化（含「被标成 photo
的动图必须改判并记录原因」）；模拟 Telegram 拒收 → **恰好一次**重处理；二次被拒 →
带明确原因的 document；端到端审核暂存 → 一个 4 图 media group、顺序正确、
**0 次 send_document**。

## 已知限制（本次不改）

- 非 JPEG 的大像素图：Pillow 只对 JPEG/MPO 提供 `draft()`，因此超解码预算的 PNG/GIF/WebP
  仍回退 document，但**现在带明确的 `decode_budget_exceeded` 原因**，不再是无解释的降级。
- **已进审核队列的历史条目无法追溯改判。** Telegram 官方明确
  *"It is not possible to change the file type when resending by file_id"*，而 TelePost
  只保存 `file_id`。已在队列里的 document 条目会保持 document，不会被删除或清空
  （不破坏 pending/published/rejected/expired 历史）。
