### PR TITLE
test(reconcile): 用观测到的心跳年龄取代墙钟 sleep，消除 release 随机失败

### DIFF
--- a/tests/test_submission_timeout_idempotency.py
+++ b/tests/test_submission_timeout_idempotency.py
@@ -117,14 +117,29 @@ async def test_reconciler_does_not_hijack_live_submission(review_db):
                         media=[{"x": 1}], documents=[])
     )
     await asyncio.wait_for(entered.wait(), timeout=5)
-    await asyncio.sleep(0.06)           # several heartbeats while still in flight
 
+    # 证明心跳确实在续命：等到 updated_at 被刷新两次，再按「观测到的年龄」推导
+    # staleness 窗口。以前这里 sleep(0.06) 后固定 stale_seconds=0.03 —— 在慢 CI
+    # runner 上，最后一次心跳到 reconcile 读取 time.time() 之间的调度抖动就会超过
+    # 0.03s，活行被误判为 crash leftover，release 的 Test 步骤随机失败
+    # （2026-09-13 TelePost release 2.17.6 build-plan 实测 1 failed）。
+    repo = ReviewRepository()
+    stamps = []
+    deadline = time.monotonic() + 10
+    while len(stamps) < 2 and time.monotonic() < deadline:
+        probe = await repo.find_active_by_key("api:9:live", 0)
+        stamp = probe["updated_at"] if probe else None
+        if stamp is not None and (not stamps or stamp > stamps[-1]):
+            stamps.append(stamp)
+        await asyncio.sleep(0.005)
+    assert len(stamps) == 2, "heartbeat never renewed the row while staging"
+
+    age = max(0.0, time.time() - stamps[-1])
     swept = await ReviewQueueService().reconcile_incomplete(
-        _Stager(), stale_seconds=0.03
+        _Stager(), stale_seconds=max(0.03, age * 20)
     )
     assert swept == 0, "the sweep repaired a live, heartbeating submission"
 
-    repo = ReviewRepository()
     row = await repo.find_active_by_key("api:9:live", 0)
     assert row["status"] == "preparing", "live row was moved by the sweep"
     assert stager.deleted == [], "live previews were deleted by the sweep"


### PR DESCRIPTION
## 为什么 block 住 release

release 2.17.6 的 `build-plan`/`Test` 步骤实测 **1 failed, 608 passed**：

```
FAILED tests/test_submission_timeout_idempotency.py::test_reconciler_does_not_hijack_live_submission
E   assert 1 == 0     — the sweep repaired a live, heartbeating submission
```

本机同一测试 **5/5 通过**，全套 609 passed / 1 skipped。所以这是环境相关的
**不稳定测试**，不是被 #70 引入的回归 —— 但它让 release 无法出 tag，
进而无法产出 `ghcr.io/redtidev1918/telepost:2.17.6` 镜像。

## 根因

测试用 `asyncio.sleep(0.06)`（≈6 个心跳周期）之后固定 `stale_seconds=0.03` 来表达
「这行还活着」。而判据的真实语义是：

```text
updated_at 由心跳每 0.01s 续命；sweep 只在 updated_at <= time.time() - stale_seconds 时才修
```

所以要证明的是「**观测到的年龄** < staleness 窗口」。慢 CI runner 上，最后一次心跳到
`reconcile_incomplete()` 读取 `time.time()` 之间的调度抖动很容易超过 0.03s，活行被
误判成 crash leftover，`assert swept == 0` 变成 `assert 1 == 0`。

## 修法（不改被测代码）

轮询 `updated_at` 直到观察到**两次刷新**（这本身就证明了心跳在跑），再按观测到的年龄
推导 staleness 窗口（`age * 20`，下限 0.03s）。测试的不变量完全不变——**仍在心跳的活行
绝不被 sweep 修复**——只是不再依赖机器速度。Test D（真正被遗弃的行仍会被修复）不受影响，
它不依赖任何时序窗口。

本机 **8/8 通过**，单次 0.14s（原来 0.34s，还更快）；全套 609 passed / 1 skipped。
